### PR TITLE
Support unversioned deps

### DIFF
--- a/3rdparty/jvm/com/chuusai/BUILD
+++ b/3rdparty/jvm/com/chuusai/BUILD
@@ -1,5 +1,3 @@
 scala_library(name = "shapeless",
-              exports = ["//3rdparty/jvm/org/scala_lang:scala_library",
-                         "//3rdparty/jvm/org/typelevel:macro_compat",
-                         "@com_chuusai_shapeless_2_11//jar:file"],
+              exports = ["@com_chuusai_shapeless_2_11//jar:file"],
               visibility = ["//visibility:public"])

--- a/3rdparty/jvm/com/github/mpilquist/BUILD
+++ b/3rdparty/jvm/com/github/mpilquist/BUILD
@@ -1,5 +1,4 @@
 scala_library(name = "simulacrum",
-              exports = ["//3rdparty/jvm/org/scala_lang:scala_library",
-                         "//3rdparty/jvm/org/typelevel:macro_compat",
+              exports = ["//3rdparty/jvm/org/typelevel:macro_compat",
                          "@com_github_mpilquist_simulacrum_2_11//jar:file"],
               visibility = ["//visibility:public"])

--- a/3rdparty/jvm/org/typelevel/BUILD
+++ b/3rdparty/jvm/org/typelevel/BUILD
@@ -34,6 +34,5 @@ scala_library(name = "machinist",
               visibility = ["//visibility:public"])
 
 scala_library(name = "macro_compat",
-              exports = ["//3rdparty/jvm/org/scala_lang:scala_library",
-                         "@org_typelevel_macro_compat_2_11//jar:file"],
+              exports = ["@org_typelevel_macro_compat_2_11//jar:file"],
               visibility = ["//visibility:public"])

--- a/3rdparty/workspace.bzl
+++ b/3rdparty/workspace.bzl
@@ -51,6 +51,6 @@ def maven_dependencies(callback):
     callback({"artifact": "org.typelevel:cats-kernel_2.11:0.6.0", "name": "org_typelevel_cats_kernel_2_11", "sha1": "03e5711e42a1459d2abfa84e56626bfcd4a1e441"})
     callback({"artifact": "org.typelevel:cats-macros_2.11:0.6.0", "name": "org_typelevel_cats_macros_2_11", "sha1": "c17b5ffff081a41b28a86e7c6047409a530551f6"})
     callback({"artifact": "org.typelevel:machinist_2.11:0.4.1", "name": "org_typelevel_machinist_2_11", "sha1": "5000250cd20d7edd8a2cd827f8786410a22a8317"})
-# duplicates in org.typelevel:macro-compat_2.11 fixed to 1.1.1. Versions: 1.1.0 1.1.1
+# duplicates in org.typelevel:macro-compat_2.11 promoted to 1.1.1. Versions: 1.1.0 1.1.1
     callback({"artifact": "org.typelevel:macro-compat_2.11:1.1.1", "name": "org_typelevel_macro_compat_2_11", "sha1": "0cb87cb74fd5fb118fede3f98075c2044616b35d"})
     callback({"artifact": "org.yaml:snakeyaml:1.12", "name": "org_yaml_snakeyaml", "sha1": "ebe66a6b88caab31d7a19571ad23656377523545"})

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -40,17 +40,14 @@ dependencies:
       lang: scala
       modules: [core, kernel, macros, free]
     macro-compat:
-      version: 1.1.1
       lang: scala
 
   com.chuusai:
     shapeless:
-      version: 2.3.1
       lang: scala  # we are not explicitly using this, but need to declare it as scala
 
   com.github.mpilquist:
     simulacrum:
-      version: 0.7.0
       lang: scala # not using explicitly, declaring as scala
 
 replacements:

--- a/src/scala/com/github/johnynek/bazel_deps/Normalizer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Normalizer.scala
@@ -54,7 +54,7 @@ object Normalizer {
         val versions = items.map(_._2).toSet
         val dups = versions.collect { case Right(v) => v }
         val rootVersion = dups.iterator.find { v =>
-          declared.recordOf(MavenCoordinate(node, v)).isDefined
+          declared.roots.contains(MavenCoordinate(node, v))
         }
         pickCanonical(node, rootVersion, dups, opts) match {
           case Right(m) =>

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -71,7 +71,7 @@ object Writer {
     def language(c: MavenCoordinate): Language = langCache.getOrElseUpdate(c, {
       import Language.{ Java, Scala }
 
-      model.dependencies.languageOf(c) match {
+      model.dependencies.languageOf(c.unversioned) match {
         case Some(l) => l
         case None =>
           Label.replaced(c, model.getReplacements) match {


### PR DESCRIPTION
This allows you to specify a dependency that should be found in the final normalized transitive graph, and set attributes (language being the only thing now). This comes up with scala deps not being clearly scala dependencies, so we need to mark them as such in some cases.