### PR TITLE
use Eval to use less memory

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -51,7 +51,7 @@ trait MakeDeps {
 
         val shas = resolver.getShas(normalized.nodes)
         // build the workspace
-        val ws = Writer.workspace(normalized, duplicates, shas, model)
+        def ws = Writer.workspace(normalized, duplicates, shas, model)
         // build the BUILDs in thirdParty
         val targets = Writer.targets(normalized, model)
         // Build up the IO operations that need to run. Till now,

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -12,7 +12,7 @@ object Writer {
 
     Traverse[List].traverseU(pathGroups) {
       case (filePath, ts) =>
-        val data = ts.sortBy(_.name.name)
+        def data = ts.sortBy(_.name.name)
           .map(_.toBazelString)
           .mkString("", "\n\n", "\n")
 


### PR DESCRIPTION
rather than store the strings we want to write in our IO.Result, use Eval so we can generate as needed (since we generally only need them one time, and we could GC immediately after writing).