### PR TITLE
use later bazel-deps to fix long file name issue

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ workspace(name = "com_github_pgr0ss_bazel_deps")
 git_repository(
     name = "io_bazel_rules_scala",
     remote = "git://github.com/bazelbuild/rules_scala",
-    commit = "6d39791d26d3f2e1d15cd6538a4767e3cc0d8993", # update this as needed
+    commit = "0fd4ccab4d0e5340ea95b887d229178526675725", # update this as needed
 )
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()


### PR DESCRIPTION
this bumps to: https://github.com/bazelbuild/rules_scala/pull/85 to work around an issue for a user.