### PR TITLE
nuke thirdparty on run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - sha256sum -c .bazel-installer-linux-x86_64.sh.sha256
   - chmod +x bazel-0.2.3-installer-linux-x86_64.sh
   - ./bazel-0.2.3-installer-linux-x86_64.sh --user
-  - mv .bazelrc.travis .bazelrc
+  - cp .bazelrc.travis .bazelrc
   - cat ~/.bazelrc >> .bazelrc
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ script:
   - bazel test //...
   - bazel build src/scala/com/github/johnynek/bazel_deps/parseproject_deploy.jar
   - ./gen_maven_deps.sh `pwd` 3rdparty/workspace.bzl dependencies.yaml
+  - git diff --exit-code

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -68,6 +68,7 @@ trait MakeDeps {
         // Build up the IO operations that need to run. Till now,
         // nothing was written
         val io = for {
+          _ <- IO.recursiveRm(IO.Path(model.getOptions.getThirdPartyDirectory.parts))
           _ <- IO.writeUtf8(IO.Path(workspacePath), ws)
           builds <- Writer.createBuildFiles(targets)
         } yield builds


### PR DESCRIPTION
This nukes the thirdparty directory on each run so that stale references don't stick around.

Clearly this means you need to be using this tool with a version control system.