### PR TITLE
Use paiges to generate BUILD files

### DIFF
--- a/3rdparty/jvm/asm/BUILD
+++ b/3rdparty/jvm/asm/BUILD
@@ -1,3 +1,11 @@
-java_library(name = "asm",
-             exports = ["//external:jar/asm/asm"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "asm",
+    exports = [
+        "//external:jar/asm/asm"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/com/chuusai/BUILD
+++ b/3rdparty/jvm/com/chuusai/BUILD
@@ -1,3 +1,11 @@
-scala_library(name = "shapeless",
-              exports = ["//external:jar/com/chuusai/shapeless_2_11"],
-              visibility = ["//visibility:public"])
+scala_library(
+    name = "shapeless",
+    exports = [
+        "//external:jar/com/chuusai/shapeless_2_11"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/com/fasterxml/jackson/core/BUILD
+++ b/3rdparty/jvm/com/fasterxml/jackson/core/BUILD
@@ -1,12 +1,38 @@
-java_library(name = "jackson_annotations",
-             exports = ["//external:jar/com/fasterxml/jackson/core/jackson_annotations"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "jackson_annotations",
+    exports = [
+        "//external:jar/com/fasterxml/jackson/core/jackson_annotations"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-java_library(name = "jackson_core",
-             exports = ["//external:jar/com/fasterxml/jackson/core/jackson_core"],
-             visibility = ["//visibility:public"])
 
-java_library(name = "jackson_databind",
-             exports = ["//external:jar/com/fasterxml/jackson/core/jackson_databind"],
-             runtime_deps = [":jackson_annotations"],
-             visibility = ["//visibility:public"])
+
+java_library(
+    name = "jackson_core",
+    exports = [
+        "//external:jar/com/fasterxml/jackson/core/jackson_core"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "jackson_databind",
+    exports = [
+        "//external:jar/com/fasterxml/jackson/core/jackson_databind"
+    ],
+    runtime_deps = [
+        ":jackson_annotations"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/com/fasterxml/jackson/dataformat/BUILD
+++ b/3rdparty/jvm/com/fasterxml/jackson/dataformat/BUILD
@@ -1,6 +1,16 @@
-java_library(name = "jackson_dataformat_yaml",
-             exports = ["//external:jar/com/fasterxml/jackson/dataformat/jackson_dataformat_yaml"],
-             runtime_deps = ["//3rdparty/jvm/com/fasterxml/jackson/core:jackson_core",
-                             "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_databind",
-                             "//3rdparty/jvm/org/yaml:snakeyaml"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "jackson_dataformat_yaml",
+    exports = [
+        "//external:jar/com/fasterxml/jackson/dataformat/jackson_dataformat_yaml"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_core",
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_databind",
+        "//3rdparty/jvm/org/yaml:snakeyaml"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/com/github/mpilquist/BUILD
+++ b/3rdparty/jvm/com/github/mpilquist/BUILD
@@ -1,4 +1,12 @@
-scala_library(name = "simulacrum",
-              exports = ["//3rdparty/jvm/org/typelevel:macro_compat",
-                         "//external:jar/com/github/mpilquist/simulacrum_2_11"],
-              visibility = ["//visibility:public"])
+scala_library(
+    name = "simulacrum",
+    exports = [
+        "//3rdparty/jvm/org/typelevel:macro_compat",
+        "//external:jar/com/github/mpilquist/simulacrum_2_11"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/com/google/code/findbugs/BUILD
+++ b/3rdparty/jvm/com/google/code/findbugs/BUILD
@@ -1,3 +1,11 @@
-java_library(name = "jsr305",
-             exports = ["//external:jar/com/google/code/findbugs/jsr305"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "jsr305",
+    exports = [
+        "//external:jar/com/google/code/findbugs/jsr305"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/com/google/guava/BUILD
+++ b/3rdparty/jvm/com/google/guava/BUILD
@@ -1,4 +1,14 @@
-java_library(name = "guava",
-             exports = ["//external:jar/com/google/guava/guava"],
-             runtime_deps = ["//3rdparty/jvm/com/google/code/findbugs:jsr305"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "guava",
+    exports = [
+        "//external:jar/com/google/guava/guava"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/com/google/code/findbugs:jsr305"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/commons_codec/BUILD
+++ b/3rdparty/jvm/commons_codec/BUILD
@@ -1,3 +1,11 @@
-java_library(name = "commons_codec",
-             exports = ["//external:jar/commons_codec/commons_codec"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "commons_codec",
+    exports = [
+        "//external:jar/commons_codec/commons_codec"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/io/circe/BUILD
+++ b/3rdparty/jvm/io/circe/BUILD
@@ -1,40 +1,98 @@
-scala_library(name = "circe_core",
-              exports = ["//external:jar/io/circe/circe_core_2_11"],
-              runtime_deps = ["//3rdparty/jvm/org/scala_lang:scala_library",
-                              "//3rdparty/jvm/org/typelevel:cats_core",
-                              ":circe_numbers_2_11"],
-              visibility = ["//visibility:public"])
+scala_library(
+    name = "circe_core",
+    exports = [
+        "//external:jar/io/circe/circe_core_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/scala_lang:scala_library",
+        "//3rdparty/jvm/org/typelevel:cats_core",
+        ":circe_numbers_2_11"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-scala_library(name = "circe_generic",
-              exports = ["//3rdparty/jvm/com/chuusai:shapeless",
-                         "//3rdparty/jvm/org/typelevel:cats_core",
-                         "//3rdparty/jvm/org/typelevel:cats_kernel",
-                         "//3rdparty/jvm/org/typelevel:macro_compat",
-                         "//external:jar/io/circe/circe_generic_2_11"],
-              runtime_deps = ["//3rdparty/jvm/org/scala_lang:scala_library",
-                              ":circe_core"],
-              visibility = ["//visibility:public"])
 
-scala_library(name = "circe_jackson",
-              exports = ["//external:jar/io/circe/circe_jackson_2_11"],
-              runtime_deps = ["//3rdparty/jvm/com/fasterxml/jackson/core:jackson_core",
-                              "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_databind",
-                              "//3rdparty/jvm/org/scala_lang:scala_library",
-                              ":circe_core"],
-              visibility = ["//visibility:public"])
 
-java_library(name = "circe_jawn_2_11",
-             exports = ["//external:jar/io/circe/circe_jawn_2_11"],
-             runtime_deps = ["//3rdparty/jvm/org/spire_math:jawn_parser_2_11"],
-             visibility = ["//visibility:public"])
+scala_library(
+    name = "circe_generic",
+    exports = [
+        "//3rdparty/jvm/com/chuusai:shapeless",
+        "//3rdparty/jvm/org/typelevel:cats_core",
+        "//3rdparty/jvm/org/typelevel:cats_kernel",
+        "//3rdparty/jvm/org/typelevel:macro_compat",
+        "//external:jar/io/circe/circe_generic_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/scala_lang:scala_library",
+        ":circe_core"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-java_library(name = "circe_numbers_2_11",
-             exports = ["//external:jar/io/circe/circe_numbers_2_11"],
-             visibility = ["//visibility:public"])
 
-scala_library(name = "circe_parser",
-              exports = ["//external:jar/io/circe/circe_parser_2_11"],
-              runtime_deps = ["//3rdparty/jvm/org/scala_lang:scala_library",
-                              ":circe_core",
-                              ":circe_jawn_2_11"],
-              visibility = ["//visibility:public"])
+
+scala_library(
+    name = "circe_jackson",
+    exports = [
+        "//external:jar/io/circe/circe_jackson_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_core",
+        "//3rdparty/jvm/com/fasterxml/jackson/core:jackson_databind",
+        "//3rdparty/jvm/org/scala_lang:scala_library",
+        ":circe_core"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "circe_jawn_2_11",
+    exports = [
+        "//external:jar/io/circe/circe_jawn_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/spire_math:jawn_parser_2_11"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "circe_numbers_2_11",
+    exports = [
+        "//external:jar/io/circe/circe_numbers_2_11"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+scala_library(
+    name = "circe_parser",
+    exports = [
+        "//external:jar/io/circe/circe_parser_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/scala_lang:scala_library",
+        ":circe_core",
+        ":circe_jawn_2_11"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/javax/annotation/BUILD
+++ b/3rdparty/jvm/javax/annotation/BUILD
@@ -1,3 +1,11 @@
-java_library(name = "jsr250_api",
-             exports = ["//external:jar/javax/annotation/jsr250_api"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "jsr250_api",
+    exports = [
+        "//external:jar/javax/annotation/jsr250_api"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/javax/enterprise/BUILD
+++ b/3rdparty/jvm/javax/enterprise/BUILD
@@ -1,4 +1,14 @@
-java_library(name = "cdi_api",
-             exports = ["//external:jar/javax/enterprise/cdi_api"],
-             runtime_deps = ["//3rdparty/jvm/javax/annotation:jsr250_api"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "cdi_api",
+    exports = [
+        "//external:jar/javax/enterprise/cdi_api"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/javax/annotation:jsr250_api"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/apache/httpcomponents/BUILD
+++ b/3rdparty/jvm/org/apache/httpcomponents/BUILD
@@ -1,9 +1,27 @@
-java_library(name = "httpclient",
-             exports = ["//external:jar/org/apache/httpcomponents/httpclient"],
-             runtime_deps = ["//3rdparty/jvm/commons_codec:commons_codec",
-                             ":httpcore"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "httpclient",
+    exports = [
+        "//external:jar/org/apache/httpcomponents/httpclient"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/commons_codec:commons_codec",
+        ":httpcore"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-java_library(name = "httpcore",
-             exports = ["//external:jar/org/apache/httpcomponents/httpcore"],
-             visibility = ["//visibility:public"])
+
+
+java_library(
+    name = "httpcore",
+    exports = [
+        "//external:jar/org/apache/httpcomponents/httpcore"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/apache/maven/BUILD
+++ b/3rdparty/jvm/org/apache/maven/BUILD
@@ -1,26 +1,62 @@
-java_library(name = "maven_aether_provider",
-             exports = ["//external:jar/org/apache/maven/maven_aether_provider"],
-             runtime_deps = ["//3rdparty/jvm/org/codehaus/plexus:plexus_component_annotations",
-                             "//3rdparty/jvm/org/codehaus/plexus:plexus_utils",
-                             "//3rdparty/jvm/org/eclipse/aether:aether_api",
-                             "//3rdparty/jvm/org/eclipse/aether:aether_impl",
-                             "//3rdparty/jvm/org/eclipse/aether:aether_spi",
-                             "//3rdparty/jvm/org/eclipse/aether:aether_util",
-                             "//3rdparty/jvm/org/eclipse/sisu:org_eclipse_sisu_plexus",
-                             ":maven_model",
-                             ":maven_model_builder",
-                             ":maven_repository_metadata"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "maven_aether_provider",
+    exports = [
+        "//external:jar/org/apache/maven/maven_aether_provider"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/codehaus/plexus:plexus_component_annotations",
+        "//3rdparty/jvm/org/codehaus/plexus:plexus_utils",
+        "//3rdparty/jvm/org/eclipse/aether:aether_api",
+        "//3rdparty/jvm/org/eclipse/aether:aether_impl",
+        "//3rdparty/jvm/org/eclipse/aether:aether_spi",
+        "//3rdparty/jvm/org/eclipse/aether:aether_util",
+        "//3rdparty/jvm/org/eclipse/sisu:org_eclipse_sisu_plexus",
+        ":maven_model",
+        ":maven_model_builder",
+        ":maven_repository_metadata"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-java_library(name = "maven_model",
-             exports = ["//external:jar/org/apache/maven/maven_model"],
-             visibility = ["//visibility:public"])
 
-java_library(name = "maven_model_builder",
-             exports = ["//external:jar/org/apache/maven/maven_model_builder"],
-             runtime_deps = ["//3rdparty/jvm/org/codehaus/plexus:plexus_interpolation"],
-             visibility = ["//visibility:public"])
 
-java_library(name = "maven_repository_metadata",
-             exports = ["//external:jar/org/apache/maven/maven_repository_metadata"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "maven_model",
+    exports = [
+        "//external:jar/org/apache/maven/maven_model"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "maven_model_builder",
+    exports = [
+        "//external:jar/org/apache/maven/maven_model_builder"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/codehaus/plexus:plexus_interpolation"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "maven_repository_metadata",
+    exports = [
+        "//external:jar/org/apache/maven/maven_repository_metadata"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/codehaus/plexus/BUILD
+++ b/3rdparty/jvm/org/codehaus/plexus/BUILD
@@ -1,15 +1,47 @@
-java_library(name = "plexus_classworlds",
-             exports = ["//external:jar/org/codehaus/plexus/plexus_classworlds"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "plexus_classworlds",
+    exports = [
+        "//external:jar/org/codehaus/plexus/plexus_classworlds"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-java_library(name = "plexus_component_annotations",
-             exports = ["//external:jar/org/codehaus/plexus/plexus_component_annotations"],
-             visibility = ["//visibility:public"])
 
-java_library(name = "plexus_interpolation",
-             exports = ["//external:jar/org/codehaus/plexus/plexus_interpolation"],
-             visibility = ["//visibility:public"])
 
-java_library(name = "plexus_utils",
-             exports = ["//external:jar/org/codehaus/plexus/plexus_utils"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "plexus_component_annotations",
+    exports = [
+        "//external:jar/org/codehaus/plexus/plexus_component_annotations"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "plexus_interpolation",
+    exports = [
+        "//external:jar/org/codehaus/plexus/plexus_interpolation"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "plexus_utils",
+    exports = [
+        "//external:jar/org/codehaus/plexus/plexus_utils"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/eclipse/aether/BUILD
+++ b/3rdparty/jvm/org/eclipse/aether/BUILD
@@ -1,41 +1,105 @@
-java_library(name = "aether_api",
-             exports = ["//external:jar/org/eclipse/aether/aether_api"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "aether_api",
+    exports = [
+        "//external:jar/org/eclipse/aether/aether_api"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-java_library(name = "aether_connector_basic",
-             exports = ["//external:jar/org/eclipse/aether/aether_connector_basic"],
-             runtime_deps = [":aether_api",
-                             ":aether_spi",
-                             ":aether_util"],
-             visibility = ["//visibility:public"])
 
-java_library(name = "aether_impl",
-             exports = ["//external:jar/org/eclipse/aether/aether_impl"],
-             runtime_deps = [":aether_api",
-                             ":aether_spi",
-                             ":aether_util"],
-             visibility = ["//visibility:public"])
 
-java_library(name = "aether_spi",
-             exports = ["//external:jar/org/eclipse/aether/aether_spi"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "aether_connector_basic",
+    exports = [
+        "//external:jar/org/eclipse/aether/aether_connector_basic"
+    ],
+    runtime_deps = [
+        ":aether_api",
+        ":aether_spi",
+        ":aether_util"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-java_library(name = "aether_transport_file",
-             exports = ["//external:jar/org/eclipse/aether/aether_transport_file"],
-             runtime_deps = [":aether_api",
-                             ":aether_spi",
-                             ":aether_util"],
-             visibility = ["//visibility:public"])
 
-java_library(name = "aether_transport_http",
-             exports = ["//external:jar/org/eclipse/aether/aether_transport_http"],
-             runtime_deps = ["//3rdparty/jvm/org/apache/httpcomponents:httpclient",
-                             "//3rdparty/jvm/org/slf4j:jcl_over_slf4j",
-                             ":aether_api",
-                             ":aether_spi",
-                             ":aether_util"],
-             visibility = ["//visibility:public"])
 
-java_library(name = "aether_util",
-             exports = ["//external:jar/org/eclipse/aether/aether_util"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "aether_impl",
+    exports = [
+        "//external:jar/org/eclipse/aether/aether_impl"
+    ],
+    runtime_deps = [
+        ":aether_api",
+        ":aether_spi",
+        ":aether_util"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "aether_spi",
+    exports = [
+        "//external:jar/org/eclipse/aether/aether_spi"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "aether_transport_file",
+    exports = [
+        "//external:jar/org/eclipse/aether/aether_transport_file"
+    ],
+    runtime_deps = [
+        ":aether_api",
+        ":aether_spi",
+        ":aether_util"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "aether_transport_http",
+    exports = [
+        "//external:jar/org/eclipse/aether/aether_transport_http"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/apache/httpcomponents:httpclient",
+        "//3rdparty/jvm/org/slf4j:jcl_over_slf4j",
+        ":aether_api",
+        ":aether_spi",
+        ":aether_util"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "aether_util",
+    exports = [
+        "//external:jar/org/eclipse/aether/aether_util"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/eclipse/sisu/BUILD
+++ b/3rdparty/jvm/org/eclipse/sisu/BUILD
@@ -1,12 +1,32 @@
-java_library(name = "org_eclipse_sisu_inject",
-             exports = ["//external:jar/org/eclipse/sisu/org_eclipse_sisu_inject"],
-             runtime_deps = ["//3rdparty/jvm/asm:asm"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "org_eclipse_sisu_inject",
+    exports = [
+        "//external:jar/org/eclipse/sisu/org_eclipse_sisu_inject"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/asm:asm"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-java_library(name = "org_eclipse_sisu_plexus",
-             exports = ["//external:jar/org/eclipse/sisu/org_eclipse_sisu_plexus"],
-             runtime_deps = ["//3rdparty/jvm/com/google/guava:guava",
-                             "//3rdparty/jvm/javax/enterprise:cdi_api",
-                             "//3rdparty/jvm/org/codehaus/plexus:plexus_classworlds",
-                             ":org_eclipse_sisu_inject"],
-             visibility = ["//visibility:public"])
+
+
+java_library(
+    name = "org_eclipse_sisu_plexus",
+    exports = [
+        "//external:jar/org/eclipse/sisu/org_eclipse_sisu_plexus"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/com/google/guava:guava",
+        "//3rdparty/jvm/javax/enterprise:cdi_api",
+        "//3rdparty/jvm/org/codehaus/plexus:plexus_classworlds",
+        ":org_eclipse_sisu_inject"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/rogach/BUILD
+++ b/3rdparty/jvm/org/rogach/BUILD
@@ -1,5 +1,15 @@
-scala_library(name = "scallop",
-              exports = ["//external:jar/org/rogach/scallop_2_11"],
-              runtime_deps = ["//3rdparty/jvm/org/scala_lang:scala_library",
-                              "//3rdparty/jvm/org/scala_lang:scala_reflect"],
-              visibility = ["//visibility:public"])
+scala_library(
+    name = "scallop",
+    exports = [
+        "//external:jar/org/rogach/scallop_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/scala_lang:scala_library",
+        "//3rdparty/jvm/org/scala_lang:scala_reflect"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/scala_lang/BUILD
+++ b/3rdparty/jvm/org/scala_lang/BUILD
@@ -1,7 +1,23 @@
-scala_library(name = "scala_library",
-              exports = ["//3rdparty/manual:scala_library_file"],
-              visibility = ["//visibility:public"])
+scala_library(
+    name = "scala_library",
+    exports = [
+        "//3rdparty/manual:scala_library_file"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-scala_library(name = "scala_reflect",
-              exports = ["//3rdparty/manual:scala_reflect_file"],
-              visibility = ["//visibility:public"])
+
+
+scala_library(
+    name = "scala_reflect",
+    exports = [
+        "//3rdparty/manual:scala_reflect_file"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/scala_lang/modules/BUILD
+++ b/3rdparty/jvm/org/scala_lang/modules/BUILD
@@ -1,8 +1,26 @@
-scala_library(name = "scala_parser_combinators",
-              exports = ["//3rdparty/manual:scala_parser_combinators_file"],
-              visibility = ["//visibility:public"])
+scala_library(
+    name = "scala_parser_combinators",
+    exports = [
+        "//3rdparty/manual:scala_parser_combinators_file"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-scala_library(name = "scala_xml",
-              exports = ["//external:jar/org/scala_lang/modules/scala_xml_2_11"],
-              runtime_deps = ["//3rdparty/jvm/org/scala_lang:scala_library"],
-              visibility = ["//visibility:public"])
+
+
+scala_library(
+    name = "scala_xml",
+    exports = [
+        "//external:jar/org/scala_lang/modules/scala_xml_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/scala_lang:scala_library"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/scala_sbt/BUILD
+++ b/3rdparty/jvm/org/scala_sbt/BUILD
@@ -1,3 +1,11 @@
-java_library(name = "test_interface",
-             exports = ["//external:jar/org/scala_sbt/test_interface"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "test_interface",
+    exports = [
+        "//external:jar/org/scala_sbt/test_interface"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/scalacheck/BUILD
+++ b/3rdparty/jvm/org/scalacheck/BUILD
@@ -1,5 +1,15 @@
-scala_library(name = "scalacheck",
-              exports = ["//external:jar/org/scalacheck/scalacheck_2_11"],
-              runtime_deps = ["//3rdparty/jvm/org/scala_lang:scala_library",
-                              "//3rdparty/jvm/org/scala_sbt:test_interface"],
-              visibility = ["//visibility:public"])
+scala_library(
+    name = "scalacheck",
+    exports = [
+        "//external:jar/org/scalacheck/scalacheck_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/scala_lang:scala_library",
+        "//3rdparty/jvm/org/scala_sbt:test_interface"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/slf4j/BUILD
+++ b/3rdparty/jvm/org/slf4j/BUILD
@@ -1,8 +1,26 @@
-java_library(name = "jcl_over_slf4j",
-             exports = ["//external:jar/org/slf4j/jcl_over_slf4j"],
-             runtime_deps = [":slf4j_api"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "jcl_over_slf4j",
+    exports = [
+        "//external:jar/org/slf4j/jcl_over_slf4j"
+    ],
+    runtime_deps = [
+        ":slf4j_api"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-java_library(name = "slf4j_api",
-             exports = ["//external:jar/org/slf4j/slf4j_api"],
-             visibility = ["//visibility:public"])
+
+
+java_library(
+    name = "slf4j_api",
+    exports = [
+        "//external:jar/org/slf4j/slf4j_api"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/spire_math/BUILD
+++ b/3rdparty/jvm/org/spire_math/BUILD
@@ -1,3 +1,11 @@
-java_library(name = "jawn_parser_2_11",
-             exports = ["//external:jar/org/spire_math/jawn_parser_2_11"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "jawn_parser_2_11",
+    exports = [
+        "//external:jar/org/spire_math/jawn_parser_2_11"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/typelevel/BUILD
+++ b/3rdparty/jvm/org/typelevel/BUILD
@@ -1,38 +1,96 @@
-scala_library(name = "cats_core",
-              exports = ["//external:jar/org/typelevel/cats_core_2_11",
-                         ":cats_kernel"],
-              runtime_deps = ["//3rdparty/jvm/com/github/mpilquist:simulacrum",
-                              "//3rdparty/jvm/org/scala_lang:scala_library",
-                              ":cats_macros",
-                              ":machinist"],
-              visibility = ["//visibility:public"])
+scala_library(
+    name = "cats_core",
+    exports = [
+        "//external:jar/org/typelevel/cats_core_2_11",
+        ":cats_kernel"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/com/github/mpilquist:simulacrum",
+        "//3rdparty/jvm/org/scala_lang:scala_library",
+        ":cats_macros",
+        ":machinist"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-scala_library(name = "cats_free",
-              exports = ["//external:jar/org/typelevel/cats_free_2_11"],
-              runtime_deps = ["//3rdparty/jvm/com/github/mpilquist:simulacrum",
-                              "//3rdparty/jvm/org/scala_lang:scala_library",
-                              ":cats_core",
-                              ":cats_macros",
-                              ":machinist"],
-              visibility = ["//visibility:public"])
 
-scala_library(name = "cats_kernel",
-              exports = ["//external:jar/org/typelevel/cats_kernel_2_11"],
-              runtime_deps = ["//3rdparty/jvm/org/scala_lang:scala_library"],
-              visibility = ["//visibility:public"])
 
-scala_library(name = "cats_macros",
-              exports = ["//external:jar/org/typelevel/cats_macros_2_11"],
-              runtime_deps = ["//3rdparty/jvm/com/github/mpilquist:simulacrum",
-                              "//3rdparty/jvm/org/scala_lang:scala_library",
-                              ":machinist"],
-              visibility = ["//visibility:public"])
+scala_library(
+    name = "cats_free",
+    exports = [
+        "//external:jar/org/typelevel/cats_free_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/com/github/mpilquist:simulacrum",
+        "//3rdparty/jvm/org/scala_lang:scala_library",
+        ":cats_core",
+        ":cats_macros",
+        ":machinist"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
 
-scala_library(name = "machinist",
-              exports = ["//external:jar/org/typelevel/machinist_2_11"],
-              runtime_deps = ["//3rdparty/jvm/org/scala_lang:scala_reflect"],
-              visibility = ["//visibility:public"])
 
-scala_library(name = "macro_compat",
-              exports = ["//external:jar/org/typelevel/macro_compat_2_11"],
-              visibility = ["//visibility:public"])
+
+scala_library(
+    name = "cats_kernel",
+    exports = [
+        "//external:jar/org/typelevel/cats_kernel_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/scala_lang:scala_library"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+scala_library(
+    name = "cats_macros",
+    exports = [
+        "//external:jar/org/typelevel/cats_macros_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/com/github/mpilquist:simulacrum",
+        "//3rdparty/jvm/org/scala_lang:scala_library",
+        ":machinist"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+scala_library(
+    name = "machinist",
+    exports = [
+        "//external:jar/org/typelevel/machinist_2_11"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/scala_lang:scala_reflect"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+scala_library(
+    name = "macro_compat",
+    exports = [
+        "//external:jar/org/typelevel/macro_compat_2_11"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/yaml/BUILD
+++ b/3rdparty/jvm/org/yaml/BUILD
@@ -1,3 +1,11 @@
-java_library(name = "snakeyaml",
-             exports = ["//external:jar/org/yaml/snakeyaml"],
-             visibility = ["//visibility:public"])
+java_library(
+    name = "snakeyaml",
+    exports = [
+        "//external:jar/org/yaml/snakeyaml"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,7 +16,7 @@ maven_dependencies(declare_maven)
 new_git_repository(
     name = "com_github_johnynek_paiges",
     remote = "git://github.com/johnynek/paiges",
-    commit = "0c74df95ac82674f8a369e293df4daf7436b44d8",
+    commit = "8b3927f5c9c2a86011fd70217ee97d708268afe4",
     # inconsistency in how we refer to build paths in new_native/new git
     build_file = "3rdparty/manual/BUILD.paiges",
     # use target: "@com_github_johnynek_paiges//:paiges"

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -11,10 +11,10 @@ import com.github.johnynek.paiges.Doc
  */
 object DocUtil {
   def packedKV(k: String, v: Doc): Doc =
-    Doc.text(k) :+ ":" + Doc.spaceOrLine.nest(2) + v
+    Doc.text(k) + Doc.text(":") + Doc.spaceOrLine.nest(2) + v
 
   def kv(k: String, v: Doc, tight: Boolean = false): Doc =
-    Doc.text(k) :+ ":" + ((Doc.line + v).nest(2))
+    Doc.text(k) + Doc.text(":") + ((Doc.line + v).nest(2))
   def quote(s: String): String = "\"%s\"".format(s)
   def quoteDoc(s: String): Doc = Doc.text(quote(s))
 

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -11,27 +11,27 @@ import com.github.johnynek.paiges.Doc
  */
 object DocUtil {
   def packedKV(k: String, v: Doc): Doc =
-    Doc.text(k) +: Doc.text(":") +: Doc.spaceOrLine.nest(2) +: v
+    Doc.text(k) :+ ":" + Doc.spaceOrLine.nest(2) + v
 
   def kv(k: String, v: Doc, tight: Boolean = false): Doc =
-    Doc.text(k) +: Doc.text(":") +: ((Doc.line +: v).nest(2))
+    Doc.text(k) :+ ":" + ((Doc.line + v).nest(2))
   def quote(s: String): String = "\"%s\"".format(s)
   def quoteDoc(s: String): Doc = Doc.text(quote(s))
 
   def list[T](i: Iterable[T])(show: T => Doc): Doc = {
-    val parts = Doc.intercalate(Doc.comma, i.map { j => (Doc.line +: show(j)).group })
+    val parts = Doc.intercalate(Doc.comma, i.map { j => (Doc.line + show(j)).grouped })
     "[" +: (parts :+ " ]").nest(2)
   }
   // Here is a vertical list of docs
   def vlist(ds: Iterable[Doc]): Doc = {
     val dash = Doc.text("- ")
-    Doc.intercalate(Doc.line, ds.map { d => dash +: d.nest(2) })
+    Doc.intercalate(Doc.line, ds.map { d => dash + d.nest(2) })
   }
 
   def yamlMap(kvs: List[(String, Doc)], lines: Int = 1): Doc = {
     def rep(x: Int): Doc =
       if (x <= 0) Doc.empty
-      else Doc.line +: rep(x - 1)
+      else Doc.line + rep(x - 1)
 
     if (kvs.isEmpty) Doc.text("{}")
     else Doc.intercalate(rep(lines), kvs.map { case (k, v) => kv(k, v) })
@@ -60,7 +60,7 @@ case class Model(
     val reps = replacements.map { r => ("replacements", r.toDoc) }
     val opts = options.map { o => ("options", o.toDoc) }
 
-    yamlMap(List(opts, deps, reps).collect { case Some(kv) => kv }, 2) +: Doc.line
+    yamlMap(List(opts, deps, reps).collect { case Some(kv) => kv }, 2) + Doc.line
   }
 }
 
@@ -364,7 +364,7 @@ case class ProjectRecord(
 
     def exportsDoc(e: Set[(MavenGroup, ArtifactOrProject)]): Doc =
       if (e.isEmpty) Doc.text("[]")
-      else (Doc.line +: vlist(toList(e).map { case (a, b) => colonPair(a, b) })).nest(2)
+      else (Doc.line + vlist(toList(e).map { case (a, b) => colonPair(a, b) })).nest(2)
 
     def quoteEmpty(s: String): Doc =
       if (s.isEmpty) quoteDoc("") else Doc.text(s)
@@ -679,7 +679,7 @@ case class Options(
       ("resolvers",
         resolvers.map {
           case Nil => Doc.text("[]")
-          case ms => (Doc.line +: vlist(ms.map(_.toDoc))).nest(2)
+          case ms => (Doc.line + vlist(ms.map(_.toDoc))).nest(2)
         }),
       ("languages",
         languages.map { ls => list(ls.map(_.asOptionsString).toList.sorted)(quoteDoc) }),

--- a/src/scala/com/github/johnynek/bazel_deps/Target.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Target.scala
@@ -81,7 +81,7 @@ case class Target(
       val nm = ("name", quote(name.name))
       val sorted = items.collect { case (s, d) if !(d.isEmpty) => (s, d) }.sorted
 
-      renderList(Doc.text("$targetType("), nm :: sorted, Doc.text(")")) { case (k, v) =>
+      renderList(targetType + Doc.text("("), nm :: sorted, Doc.text(")")) { case (k, v) =>
         k +: " = " +: v
       } + Doc.line.repeat(2)
     }

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -18,7 +18,7 @@ object Writer {
           else s + "\n"
 
         def data = ts.sortBy(_.name.name)
-          .map(_.toBazelString)
+          .map(_.toDoc.render(60))
           .mkString(withNewline(buildHeader), "\n\n", "\n")
 
           for {

--- a/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
@@ -297,7 +297,7 @@ maven_dependencies(maven_load)
 
       val thisBuild = if (proj.packaging == "jar") {
         def contents(t: Target): String =
-          header.fold("\n")(_ + "\n") ++ t.toBazelString
+          header.fold("\n")(_ + "\n") ++ t.toDoc.render(60)
 
         for {
           labs <- depLabels


### PR DESCRIPTION
This cleans up the generation of BUILD files and makes them closer, but not maybe yet exactly, what https://github.com/bazelbuild/buildtools would do.

It would be nice to generate something that is transparent to buildifier (which is basically implementing half of buildifier, the other half being a parser).