### PR TITLE
Change the Normalization algorithm

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/src/scala/com/github/johnynek/bazel_deps/BUILD
@@ -19,6 +19,8 @@ scala_library(name = "commands",
 
 scala_library(name = "graph",
               srcs = ["Graph.scala"],
+              deps = ["@org_typelevel_paiges//:paiges"],
+              exports = ["@org_typelevel_paiges//:paiges"],
               visibility = ["//visibility:public"])
 
 scala_repl(name = "repl",
@@ -54,6 +56,7 @@ scala_library(name = "normalizer",
               srcs = ["Normalizer.scala"],
               deps = [":depsmodel",
                       ":graph",
+                      "@org_typelevel_paiges//:paiges",
                       ],
               visibility = ["//visibility:public"])
 

--- a/src/scala/com/github/johnynek/bazel_deps/Graph.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Graph.scala
@@ -1,8 +1,25 @@
 package com.github.johnynek.bazel_deps
 
+import org.typelevel.paiges.Doc
+
 case class Edge[N, E](source: N, destination: N, label: E)
 
 case class Graph[N, E](nodes: Set[N], edges: Map[N, Set[Edge[N, E]]]) {
+  def toDoc(showN: N => String, showE: E => String): Doc = {
+    val tab = nodes
+      .toList
+      .sortBy(showN)
+      .map { n =>
+        val strN = showN(n)
+        val es = hasSource(n)
+        val edoc = Doc.intercalate(Doc.line, es.map { case Edge(_, d, e) =>
+          Doc.text(s"-(${showE(e)})->") + Doc.space + Doc.text(showN(d))
+        })
+        (strN, edoc)
+      }
+    Doc.tabulate(' ', ":", tab)
+  }
+
   def edgeIterator: Iterator[Edge[N, E]] =
     edges.iterator.flatMap { case (n, es) =>
       // each edge appears twice, only return the ones where

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -32,7 +32,7 @@ object MakeDeps {
     // This is a defensive check that can be removed as we add more tests
     deps.roots.foreach { m => require(graph.nodes(m), s"$m") }
 
-    Normalizer(graph, deps, model.getOptions) match {
+    Normalizer(graph, deps.roots.toList, model.getOptions.getVersionConflictPolicy) match {
       case None =>
         println("[ERROR] could not normalize versions:")
         println(graph.nodes.groupBy(_.unversioned)

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -32,7 +32,7 @@ object MakeDeps {
     // This is a defensive check that can be removed as we add more tests
     deps.roots.foreach { m => require(graph.nodes(m), s"$m") }
 
-    Normalizer(graph, deps.roots.toList, model.getOptions.getVersionConflictPolicy) match {
+    Normalizer(graph, deps.roots, model.getOptions.getVersionConflictPolicy) match {
       case None =>
         println("[ERROR] could not normalize versions:")
         println(graph.nodes.groupBy(_.unversioned)

--- a/src/scala/com/github/johnynek/bazel_deps/Normalizer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Normalizer.scala
@@ -26,7 +26,7 @@ object Normalizer {
    * and updates the dependency graph.
    */
   def apply(graph: Graph[MavenCoordinate, Unit],
-    roots: List[MavenCoordinate],
+    roots: Set[MavenCoordinate],
     vcf: VersionConflictPolicy): Option[Graph[MavenCoordinate, Unit]] = {
 
     @annotation.tailrec

--- a/src/scala/com/github/johnynek/bazel_deps/Normalizer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Normalizer.scala
@@ -1,19 +1,33 @@
 package com.github.johnynek.bazel_deps
 
 import cats.data.{ Validated, ValidatedNel }
+import org.typelevel.paiges.Doc
 
 object Normalizer {
   type Candidate = Either[Set[Version], Version]
+  type Node = UnversionedCoordinate
   type Table = Map[Node, List[(Option[MavenCoordinate], Candidate)]]
 
-  type Node = UnversionedCoordinate
+  def tableToDoc(t: Table): Doc = {
+    val pairs = t.map { case (n, versions) =>
+      val versionDocs = versions.map { case (opt, c) =>
+        val mvn = opt.fold("None")(_.asString)
+        val cand = Doc.str(c) // could be prettier
+        (mvn, cand)
+      }
+      val tabbed = Doc.tabulate(' ', " => ", versionDocs)
+      (n.asString, tabbed)
+    }
+    Doc.tabulate(' ', " -> ", pairs)
+  }
+
   /**
    * assumes every depth less than d has no duplication. Looks at d and greater
    * and updates the dependency graph.
    */
   def apply(graph: Graph[MavenCoordinate, Unit],
-    declared: Dependencies,
-    opts: Options): Option[Graph[MavenCoordinate, Unit]] = {
+    roots: List[MavenCoordinate],
+    vcf: VersionConflictPolicy): Option[Graph[MavenCoordinate, Unit]] = {
 
     @annotation.tailrec
     def fixTable(table: Table): Table = {
@@ -56,9 +70,9 @@ object Normalizer {
         val versions = items.map(_._2).toSet
         val dups = versions.collect { case Right(v) => v }
         val rootVersion = dups.iterator.find { v =>
-          declared.roots.contains(MavenCoordinate(node, v))
+          roots.contains(MavenCoordinate(node, v))
         }
-        pickCanonical(node, rootVersion, dups, opts) match {
+        pickCanonical(node, rootVersion, dups, vcf) match {
           case Validated.Valid(m) =>
             val newItems = items.map { case (p, _) => (p, Right(m.version)) }
             table.updated(node, newItems)
@@ -99,13 +113,7 @@ object Normalizer {
         }
 
     val newTable = fixTable(table)
-    rewrite(graph, newTable).map { rewrittenGraph =>
-      // We now filter only those nodes that are in the
-      // reflexive transitive closure of the declared nodes
-      val reachable = rewrittenGraph.reflexiveTransitiveClosure(declared.roots.toList)
-      // remove all nodes not in this set
-      (rewrittenGraph.nodes -- reachable).foldLeft(rewrittenGraph)(_.removeNode(_))
-    }
+    rewrite(graph, roots.toList, newTable)
   }
 
   private def compact(t: Table): Map[UnversionedCoordinate, Version] =
@@ -117,7 +125,7 @@ object Normalizer {
       }
     }.toMap
 
-  def isKeeper(m: MavenCoordinate, t: Table): Boolean =
+  private def isKeeper(m: MavenCoordinate, t: Table): Boolean =
     t.get(m.unversioned) match {
       case None => false
       case Some(vs) => vs.forall {
@@ -126,28 +134,34 @@ object Normalizer {
       }
     }
 
-  private def rewrite(g: Graph[MavenCoordinate, Unit], t: Table) = {
+  private def rewrite(g: Graph[MavenCoordinate, Unit], roots: List[MavenCoordinate], t: Table): Option[Graph[MavenCoordinate, Unit]] = {
     if (t.forall { case (_, vs) => vs.forall(_._2.isRight) }) {
-      val versions = g.nodes.groupBy(_.unversioned).mapValues(_.map(_.version))
       val canonicals = compact(t)
 
-      def retarget(g0: Graph[MavenCoordinate, Unit], n0: MavenCoordinate): Graph[MavenCoordinate, Unit] =
-        if (isKeeper(n0, t)) {
-          val dependencies = g0.hasSource(n0).map(_.destination)
-          dependencies.foldLeft(g0)(retarget)
-        }
-        else {
-          // rewrite all the edges that terminate at us
-          // things that depend on us need to start depending on someone else
-          val u = n0.unversioned
-          val version = canonicals(u)
-          val newTarget = MavenCoordinate(u, version)
-          g0.hasDestination(n0).foldLeft(g0) { (g, edge) =>
-            g.removeEdge(edge).addEdge(Edge(edge.source, newTarget, ()))
-          }
+      @annotation.tailrec
+      def addReachable(acc: Graph[MavenCoordinate, Unit], toProcess: List[UnversionedCoordinate], processed: Set[UnversionedCoordinate]): Graph[MavenCoordinate, Unit] =
+        toProcess match {
+          case Nil => acc
+          case h :: tail if processed(h) => addReachable(acc, tail, processed)
+          case h :: tail =>
+            val versionedH = MavenCoordinate(h, canonicals(h))
+            // we want to add this, and all the nodes this versionedH pointed to in original graph
+            val dependenciesUv: Set[UnversionedCoordinate] =
+              g.hasSource(versionedH).map(_.destination.unversioned)
+
+            val dependencies = dependenciesUv.map { uv =>
+              MavenCoordinate(uv, canonicals(uv))
+            }
+            // add the edges from versionedH -> deps
+            val newGraph = dependencies.foldLeft(acc) { (g, dep) =>
+              g.addEdge(Edge(versionedH, dep, ()))
+            }
+            // now process all dependencies:
+            addReachable(newGraph, (dependenciesUv.filterNot(processed)).toList ::: toProcess, processed + h)
         }
 
-      Some(g.roots.foldLeft(g)(retarget))
+      val queue = roots.map(_.unversioned)
+      Some(addReachable(Graph.empty, queue, Set.empty))
     }
     else None
   }
@@ -156,8 +170,8 @@ object Normalizer {
     unversioned: UnversionedCoordinate,
     rootVersion: Option[Version],
     duplicates: Set[Version],
-    opts: Options): ValidatedNel[String, MavenCoordinate] =
-      opts.getVersionConflictPolicy
+    vcf: VersionConflictPolicy): ValidatedNel[String, MavenCoordinate] =
+      vcf
         .resolve(rootVersion, duplicates)
         .map { v => MavenCoordinate(unversioned, v) }
 }

--- a/test/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/test/scala/com/github/johnynek/bazel_deps/BUILD
@@ -9,6 +9,15 @@ scala_test(name = "graphtest",
            deps = ["//src/scala/com/github/johnynek/bazel_deps:graph",
                    "//3rdparty/jvm/org/scalacheck"])
 
+scala_test(name = "normalizertest",
+           srcs = ["NormalizerTest.scala"],
+           size = "small",
+           deps = [
+               "//src/scala/com/github/johnynek/bazel_deps:depsmodel",
+               "//src/scala/com/github/johnynek/bazel_deps:graph",
+               "//src/scala/com/github/johnynek/bazel_deps:normalizer",
+               "//3rdparty/jvm/org/scalacheck"])
+
 scala_library(name = "modelgen",
            srcs = ["ModelGenerators.scala"],
            deps = ["//src/scala/com/github/johnynek/bazel_deps:depsmodel",

--- a/test/scala/com/github/johnynek/bazel_deps/NormalizerTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/NormalizerTest.scala
@@ -1,0 +1,52 @@
+package com.github.johnynek.bazel_deps
+
+import org.scalatest.FunSuite
+import org.scalatest.prop.Checkers.check
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{ Gen, Arbitrary }
+
+class NormalizerTest extends FunSuite  {
+  test("test normalization with a simple example") {
+
+    val g = Graph.empty[MavenCoordinate, Unit]
+
+    implicit class AbuseGraph(val g: Graph[MavenCoordinate, Unit]) {
+      def add(from: String, to: String): Graph[MavenCoordinate, Unit] =
+        g.addEdge(Edge(MavenCoordinate(from), MavenCoordinate(to), ()))
+    }
+
+
+    val cat1 = "a:cat:1.0"
+    val snake1 = "a:snake:1.0"
+    val bird1 = "a:bird:1.0"
+    val bird2 = "a:bird:2.0"
+    val seed1 = "a:seed:1.0"
+    /**
+     * a:cat:1.0 -> a:bird:1.0
+     * a:snake:1.0 -> a:bird:2.0
+     * a:bird:1.0 -> a:worm:1.0
+     * a:bird:2.0 -> a:seed:1.0
+     *
+     * roots: cat, snake
+     *
+     * goal: no bird:1.0 or worm:1.0
+     */
+    val finalG = g
+      .add(cat1, bird1)
+      .add(snake1, bird2)
+      .add(bird1, "a:worm:1.0")
+      .add(bird2, seed1)
+
+    Normalizer(finalG, List(cat1, snake1).map(MavenCoordinate(_)), VersionConflictPolicy.default) match {
+      case Some(normalG) =>
+        val expected = g
+          .add(cat1, bird2)
+          .add(snake1, bird2)
+          .add(bird2, seed1)
+
+        assert(normalG === expected)
+
+      case None => fail("could not normalize")
+    }
+  }
+}

--- a/test/scala/com/github/johnynek/bazel_deps/NormalizerTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/NormalizerTest.scala
@@ -37,7 +37,7 @@ class NormalizerTest extends FunSuite  {
       .add(bird1, "a:worm:1.0")
       .add(bird2, seed1)
 
-    Normalizer(finalG, List(cat1, snake1).map(MavenCoordinate(_)), VersionConflictPolicy.default) match {
+    Normalizer(finalG, Set(cat1, snake1).map(MavenCoordinate(_)), VersionConflictPolicy.default) match {
       case Some(normalG) =>
         val expected = g
           .add(cat1, bird2)


### PR DESCRIPTION
This adds a test for a bug we observed in how we
rewrite the Normalized graph. The old algorithm
had bugs and was more complex. The current algorithm
builds up the final graph by starting at the roots
with the normalized versions of anything reachable.