### PR TITLE
New option to configure the path where bazel-deps will cache resolved packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,16 @@ In the options we set:
 * versionConflictPolicy: `fixed`, `fail` or `highest`
 * transitivity: `runtime_deps` or `exports`
 * resolvers: the maven servers to use.
+* resolverCache: where bazel-deps should cache resolved packages.  `local` (`target/local-repo` in the repository root)
+  or `bazel_output_base` (`bazel-deps/local-repo` inside the repository's Bazel output base -- from `bazel info
+  output_base`)
 
-In the default case, with no options given, we use the `highest` versionConflictPolicy,
-exports transitivity, allow java and scala `2.11`, and use maven central as the resolver.
+In the default case, with no options given, we use:
+- `highest` versionConflictPolicy
+- `exports` transitivity
+- allow java and scala `2.11`
+- use maven central as the resolver
+- `local` resolverCache
 
 ### <a name="replacements">Replacements</a>
 Some maven jars should not be used and instead are replaced by internal targets. Here are

--- a/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
@@ -15,6 +15,12 @@ object Decoders {
       case "runtime_deps" => Right(Transitivity.RuntimeDeps)
       case other => Left(s"unrecogized transitivity: $other")
     }
+  implicit val resolverCacheDecoder: Decoder[ResolverCache] =
+    Decoder.decodeString.emap {
+      case "local" => Right(ResolverCache.Local)
+      case "bazel_output_base" => Right(ResolverCache.BazelOutputBase)
+      case other => Left(s"unrecogized resolverCache: $other")
+    }
   implicit val groupArtDecoder: Decoder[(MavenGroup, ArtifactOrProject)] =
     Decoder.decodeString.emap { s =>
       s.split(':') match {

--- a/src/scala/com/github/johnynek/bazel_deps/Resolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Resolver.scala
@@ -2,6 +2,7 @@ package com.github.johnynek.bazel_deps
 
 import java.security.MessageDigest
 import java.io.{ File, FileInputStream }
+import java.nio.file.Path
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils
 import org.eclipse.aether.RepositorySystem
 import org.eclipse.aether.artifact.DefaultArtifact
@@ -24,7 +25,7 @@ case class ResolveFailure(message: String,
   extension: String,
   failures: List[Exception]) extends Exception(message)
 
-class Resolver(servers: List[MavenServer]) {
+class Resolver(servers: List[MavenServer], resolverCachePath: Path) {
 
   private val system = {
     val locator = MavenRepositorySystemUtils.newServiceLocator
@@ -43,7 +44,7 @@ class Resolver(servers: List[MavenServer]) {
 
   private val session = {
     val s = MavenRepositorySystemUtils.newSession()
-    val localRepo = new LocalRepository("target/local-repo")
+    val localRepo = new LocalRepository(resolverCachePath.toString)
     s.setLocalRepositoryManager(system.newLocalRepositoryManager(s, localRepo))
     s
   }

--- a/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
@@ -55,7 +55,8 @@ object ModelGenerators {
     res <- Gen.option(Gen.listOf(mavenServerGen))
     trans <- Gen.option(Gen.oneOf(Transitivity.RuntimeDeps, Transitivity.Exports))
     heads <- Gen.option(Gen.listOf(Gen.identifier))
-  } yield Options(vcp, dir, langs, res, trans, heads)
+    cache <- Gen.option(Gen.oneOf(ResolverCache.Local, ResolverCache.BazelOutputBase))
+  } yield Options(vcp, dir, langs, res, trans, heads, cache)
 
   val modelGen: Gen[Model] = for {
     o <- Gen.option(optionGen)

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
@@ -42,6 +42,7 @@ class ParseTest extends FunSuite {
                 |options:
                 |  languages: ["scala:2.11.7", java]
                 |  thirdPartyDirectory: 3rdparty/jvm
+                |  resolverCache: bazel_output_base
                 |""".stripMargin('|')
 
     assert(Decoders.decodeModel(Yaml, str) ==
@@ -63,7 +64,8 @@ class ParseTest extends FunSuite {
               Some(Set(Language.Scala(Version("2.11.7"), true), Language.Java)),
               None,
               None,
-              None)))))
+              None,
+              Some(ResolverCache.BazelOutputBase))))))
   }
   test("parse empty subproject version") {
     val str = """dependencies:
@@ -96,6 +98,7 @@ class ParseTest extends FunSuite {
               None,
               Some(DirectoryName("3rdparty/jvm")),
               Some(Set(Language.Scala(Version("2.11.7"), true), Language.Java)),
+              None,
               None,
               None,
               None)))))


### PR DESCRIPTION
Previously, the resolver cached packages in `target/local-repo` in the current working directory.  Now, two behaviors
are available via the `resolverCache` option:

- `local`: This is the existing behavior and the new default.
- `bazel_output_base`: Cache packages to `bazel-deps/local-repo` inside the current project's Bazel output base.  This
  path is resolved by running `bazel info output_base` for the project passed as `--repo-root`.  This path has the
  benefit of surviving `git clean -x`, but can still be removed with `bazel clean --expunge`.