### PR TITLE
properly handle empty subproject when flattening dependencies (fixes #57)

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -140,8 +140,13 @@ case class ArtifactOrProject(asString: String) {
     }
     else Nil
 
-  def toArtifact(sp: Subproject): ArtifactOrProject =
-    ArtifactOrProject(s"$asString-${sp.asString}")
+  def toArtifact(sp: Subproject): ArtifactOrProject = {
+    val str = sp.asString
+    str match {
+      case "" => this
+      case _ => ArtifactOrProject(s"$asString-$str")
+    }
+  }
 }
 case class Subproject(asString: String)
 case class Version(asString: String)


### PR DESCRIPTION
A trailing hyphen should not be appended if there is no subproject name; doing so generates an invalid artifact.

I don't think this fixes all of #44 but only the second part that I reported as #57, but I can't repro it to test for sure.