### PR TITLE
New flag: --inline-callback obviates load.bzl

### DIFF
--- a/3rdparty/load.bzl
+++ b/3rdparty/load.bzl
@@ -1,7 +1,0 @@
-def declare_maven(item):
-  sha = item.get("sha1")
-  if sha != None:
-    native.maven_jar(name = item["name"], artifact = item["artifact"], sha1 = sha)
-  else:
-    native.maven_jar(name = item["name"], artifact = item["artifact"])
-  native.bind(name = item["bind"], actual = item["actual"])

--- a/3rdparty/workspace.bzl
+++ b/3rdparty/workspace.bzl
@@ -1,4 +1,16 @@
-def maven_dependencies(callback):
+def declare_maven(hash):
+    native.maven_jar(
+        name = hash["name"],
+        artifact = hash["artifact"],
+        sha1 = hash["sha1"],
+        repository = hash["repository"]
+    )
+    native.bind(
+        name = hash["bind"],
+        actual = hash["actual"]
+    )
+
+def maven_dependencies(callback = declare_maven):
     callback({"artifact": "asm:asm:3.3.1", "lang": "java", "sha1": "1d5f20b4ea675e6fab6ab79f1cd60ec268ddc015", "repository": "https://repo.maven.apache.org/maven2/", "name": "asm_asm", "actual": "@asm_asm//jar", "bind": "jar/asm/asm"})
     callback({"artifact": "com.chuusai:shapeless_2.11:2.3.2", "lang": "scala", "sha1": "f40ed6e303d550293f5f8f3743681d98e31f2360", "repository": "https://repo.maven.apache.org/maven2/", "name": "com_chuusai_shapeless_2_11", "actual": "@com_chuusai_shapeless_2_11//jar:file", "bind": "jar/com/chuusai/shapeless_2_11"})
     callback({"artifact": "com.fasterxml.jackson.core:jackson-annotations:2.5.0", "lang": "java", "sha1": "a2a55a3375bc1cef830ca426d68d2ea22961190e", "repository": "https://repo.maven.apache.org/maven2/", "name": "com_fasterxml_jackson_core_jackson_annotations", "actual": "@com_fasterxml_jackson_core_jackson_annotations//jar", "bind": "jar/com/fasterxml/jackson/core/jackson_annotations"})

--- a/README.md
+++ b/README.md
@@ -21,26 +21,10 @@ for any exceptions that you manage along with [Replacements](#replacements).
 Then you should add
 ```
 load("//3rdparty:workspace.bzl", "maven_dependencies")
-load("//3rdparty:load.bzl", "declare_maven")
 
-maven_dependencies(declare_maven)
+maven_dependencies()
 ```
-
-To your workspace to load the maven dependencies. Note you will need to implement load.bzl `declare_maven`. A standard implementation
-might be:
-```python
-def declare_maven(hash):
-    native.maven_jar(
-        name = hash["name"],
-        artifact = hash["artifact"],
-        sha1 = hash["sha1"],
-        repository = hash["repository"]
-    )
-    native.bind(
-        name = hash["bind"],
-        actual = hash["actual"]
-    )
-```
+to your workspace to load the maven dependencies.
 
 ## Assumptions and usage
 This tool will generate one canonical version for every jar in the transitive dependencies of

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,9 +9,8 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()
 
 load("//3rdparty:workspace.bzl", "maven_dependencies")
-load("//3rdparty:load.bzl", "declare_maven")
 
-maven_dependencies(declare_maven)
+maven_dependencies()
 
 new_git_repository(
     name = "org_typelevel_paiges",

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -77,7 +77,21 @@ object Writer {
              s"""${kv("bind", coord.unversioned.toBindingName)}})""").mkString(", ")
       }
       .mkString("\n")
-    s"""def maven_dependencies(callback):\n$lines\n"""
+    s"""def declare_maven(hash):
+        |    native.maven_jar(
+        |        name = hash["name"],
+        |        artifact = hash["artifact"],
+        |        sha1 = hash["sha1"],
+        |        repository = hash["repository"]
+        |    )
+        |    native.bind(
+        |        name = hash["bind"],
+        |        actual = hash["actual"]
+        |    )
+        |
+        |def maven_dependencies(callback = declare_maven):
+        |$lines
+        |""".stripMargin
   }
 
   def language(g: Graph[MavenCoordinate, Unit],


### PR DESCRIPTION
When turned on, a user doesn't have to provide a callback when calling maven_dependencies() from their WORKSPACE file.
Instead, maven_dependencies() will call a function defined in the same .bzl file that calls native.maven_jar() or equivalent.

The goal is to simplify setting up a project to work with bazel-deps.

Fixes #60 .