### PR TITLE
add support for namePrefix option, to avoid conflicts with generated names

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ In the options we set:
 * resolverCache: where bazel-deps should cache resolved packages.  `local` (`target/local-repo` in the repository root)
   or `bazel_output_base` (`bazel-deps/local-repo` inside the repository's Bazel output base -- from `bazel info
   output_base`)
+* namePrefix: a string added to the generated workspace names, to avoid conflicts.  The external repository names and
+  binding targets of each dependency are prefixed.
 
 In the default case, with no options given, we use:
 - `highest` versionConflictPolicy
@@ -96,6 +98,7 @@ In the default case, with no options given, we use:
 - allow java and scala `2.11`
 - use maven central as the resolver
 - `local` resolverCache
+- empty namePrefix (`""`)
 
 ### <a name="replacements">Replacements</a>
 Some maven jars should not be used and instead are replaced by internal targets. Here are

--- a/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
@@ -21,6 +21,7 @@ object Decoders {
       case "bazel_output_base" => Right(ResolverCache.BazelOutputBase)
       case other => Left(s"unrecogized resolverCache: $other")
     }
+  implicit val namePrefixDecoder: Decoder[NamePrefix] = stringWrapper(NamePrefix(_))
   implicit val groupArtDecoder: Decoder[(MavenGroup, ArtifactOrProject)] =
     Decoder.decodeString.emap { s =>
       s.split(':') match {

--- a/src/scala/com/github/johnynek/bazel_deps/Label.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Label.scala
@@ -25,10 +25,10 @@ object Label {
     val target = pathAndTarg.drop(1 + pathStr.length)
     Label(ws, Path(pathStr.split('/').toList), target)
   }
-  def externalJar(lang: Language, u: UnversionedCoordinate): Label = lang match {
-    case Language.Java => Label(Some(u.toBazelRepoName), Path(List("jar")), "")
+  def externalJar(lang: Language, u: UnversionedCoordinate, np: NamePrefix): Label = lang match {
+    case Language.Java => Label(Some(u.toBazelRepoName(np)), Path(List("jar")), "")
     // If we know we have a scala jar, just use ":file" to be sure we can deal with macros
-    case Language.Scala(_, _) => Label(Some(u.toBazelRepoName), Path(List("jar")), "file")
+    case Language.Scala(_, _) => Label(Some(u.toBazelRepoName(np)), Path(List("jar")), "file")
   }
 
   def replaced(u: UnversionedCoordinate, r: Replacements): Option[(Label, Language)] =

--- a/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
@@ -59,7 +59,8 @@ object ModelGenerators {
     trans <- Gen.option(Gen.oneOf(Transitivity.RuntimeDeps, Transitivity.Exports))
     heads <- Gen.option(Gen.listOf(Gen.identifier))
     cache <- Gen.option(Gen.oneOf(ResolverCache.Local, ResolverCache.BazelOutputBase))
-  } yield Options(vcp, dir, langs, res, trans, heads, cache)
+    prefix <- Gen.option(Gen.identifier.map(NamePrefix(_)))
+  } yield Options(vcp, dir, langs, res, trans, heads, cache, prefix)
 
   val modelGen: Gen[Model] = for {
     o <- Gen.option(optionGen)

--- a/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
@@ -69,4 +69,16 @@ class ModelTest extends FunSuite {
         assert(combined.toDoc.render(100) == str)
     }
   }
+
+  test("coordinate naming") {
+    val uc = UnversionedCoordinate(MavenGroup("com.twitter"), MavenArtifactId("finagle-core"))
+    assert(uc.asString == "com.twitter:finagle-core")
+    assert(uc.toBazelRepoName(NamePrefix("")) == "com_twitter_finagle_core")
+    assert(uc.toBindingName(NamePrefix("")) == "jar/com/twitter/finagle_core")
+    assert(uc.bindTarget(NamePrefix("")) == "//external:jar/com/twitter/finagle_core")
+    val np = NamePrefix("unique_")
+    assert(uc.toBazelRepoName(np) == "unique_com_twitter_finagle_core")
+    assert(uc.toBindingName(np) == "jar/unique_com/twitter/finagle_core")
+    assert(uc.bindTarget(np) == "//external:jar/unique_com/twitter/finagle_core")
+  }
 }

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
@@ -65,7 +65,8 @@ class ParseTest extends FunSuite {
               None,
               None,
               None,
-              Some(ResolverCache.BazelOutputBase))))))
+              Some(ResolverCache.BazelOutputBase),
+              None)))))
   }
   test("parse empty subproject version") {
     val str = """dependencies:
@@ -98,6 +99,7 @@ class ParseTest extends FunSuite {
               None,
               Some(DirectoryName("3rdparty/jvm")),
               Some(Set(Language.Scala(Version("2.11.7"), true), Language.Java)),
+              None,
               None,
               None,
               None,


### PR DESCRIPTION
My particular use case of this is having two dependencies.yaml files in the same repository, with different versions of certain artifacts and different `thirdPartyDirectory`s.  Without this prefixing, the names used in the workspace and for `bind` conflict.