### PR TITLE
Improve the yaml minimization algorithm (again).

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,7 @@ maven_dependencies()
 new_git_repository(
     name = "org_typelevel_paiges",
     remote = "git://github.com/typelevel/paiges",
-    commit = "5c39b9e17238d7fa04013e10bf732a3ac58a496d",
+    commit = "0cdb92ac7f40cb251a76077cb0ac92b68a620c57",
     # inconsistency in how we refer to build paths in new_native/new git
     build_file = "3rdparty/manual/BUILD.paiges",
     # use target: "@org_typelevel_paiges//:paiges"

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -625,7 +625,7 @@ object Dependencies {
    * Combine as many ProjectRecords as possible into a result
    */
   def normalize(candidates0: List[(ArtifactOrProject, ProjectRecord)]): List[(ArtifactOrProject, ProjectRecord)] = {
-    type AP= (ArtifactOrProject, ProjectRecord)
+    type AP = (ArtifactOrProject, ProjectRecord)
 
     def group[A, B](abs: List[(A, B)]): List[(A, List[B])] =
       abs.groupBy(_._1).map { case (k, vs) => k -> vs.map(_._2) }.toList

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -668,32 +668,27 @@ object Dependencies {
           // this AP can't appear in others:
           val case1 = manyWorlds(newCand, (art, newPR) :: acc)
 
+          // If we can still skip this (pr, subs) item and still
+          // find homes for all the AP pairs in subs, then try
+          def maybeRecurse(g: CandidateGraph): List[List[AP]] = {
+            val aps = subs.iterator.map(_._2)
+            val stillPaths = aps.filterNot(apsIn(g)).isEmpty
+            if (stillPaths) manyWorlds(g, acc)
+            else Nil
+          }
+
           // or we could have not used this (art, pr) pair at all if there is
           // something else to use it in rest:
-          val case2 = rest match {
-            case Nil => Nil
-            case notEmpty =>
-              // if any APs in subs don't appear in the rest this can't be successful
-              // check that before we recurse
-              val aps = subs.iterator.map(_._2)
-              val next = (art, rest) :: tail
-              val stillPaths = aps.filterNot(apsIn(next)).isEmpty
-              if (stillPaths) manyWorlds(next, acc)
-              else Nil
-          }
+          // if any APs in subs don't appear in the rest this can't be successful
+          // check that before we recurse
+          val case2 = maybeRecurse((art, rest) :: tail)
+
           // or we could have just skipped using this art entirely
           // so that we don't exclude APs associated with it from
           // better matches
-          val case3 = tail match {
-            case Nil => Nil
-            case notEmpty =>
-              // if any APs in subs don't appear in the rest this can't be successful
-              // check that before we recurse
-              val aps = subs.iterator.map(_._2)
-              val stillPaths = aps.filterNot(apsIn(notEmpty)).isEmpty
-              if (stillPaths) manyWorlds(notEmpty, acc)
-              else Nil
-          }
+          // if any APs in subs don't appear in the rest this can't be successful
+          // check that before we recurse
+          val case3 = maybeRecurse(tail)
 
           case1 reverse_::: case2 reverse_::: case3
       }

--- a/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
@@ -29,23 +29,6 @@ class ModelTest extends FunSuite {
     assert(rand.sorted === sorted)
   }
 
-  test("project record combination works") {
-    def makeRec(artifact: String, module: Option[String]): (ArtifactOrProject, ProjectRecord) =
-      (ArtifactOrProject(artifact), ProjectRecord(
-        Language.Java,
-        None,
-        module.map { s => Set(Subproject(s)) },
-        None,
-        None))
-
-    Dependencies.merge(makeRec("poi", None), makeRec("poi-ooxml", None)) match {
-      case Some((ap, pr)) =>
-        assert(ap == ArtifactOrProject("poi"))
-        assert(pr.modules.get.map(_.asString) == Set("", "ooxml"))
-      case None => fail("couldn't merge")
-    }
-  }
-
   test("empty subproject is merged correctly with new submodule") {
     val lang = Language.Scala.default
     val deps = Dependencies(Map(

--- a/test/scala/com/github/johnynek/bazel_deps/ParseGeneratedDocTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseGeneratedDocTest.scala
@@ -1,5 +1,6 @@
 package com.github.johnynek.bazel_deps
 
+import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks._
 import ParseTestUtil._
@@ -8,9 +9,21 @@ class ParseGeneratedDocTest extends FunSuite {
   test("parse randomly generated Model.toDoc") {
     // this test is slow and takes a lot of memory sadly
     implicit val generatorDrivenConfig =
-      PropertyCheckConfig(minSuccessful = 200)
+      PropertyCheckConfig(minSuccessful = 50)
 
     forAll(ModelGenerators.modelGen)(law _)
   }
 
+  test("Dependencies.normalize laws") {
+
+    val genList = Gen.listOf(Gen.zip(ModelGenerators.artifactOrProjGen, ModelGenerators.projectRecordGen(Language.Java, Nil)))
+
+    forAll(genList) { lp =>
+      val output = Dependencies.normalize(lp)
+      assert(lp.size <= output.size)
+      val flat1 = lp.flatMap { case (a, p) => p.flatten(a) }
+      val flat2 = output.flatMap { case (a, p) => p.flatten(a) }
+      assert(flat1.toSet == flat2.toSet)
+    }
+  }
 }

--- a/test/scala/com/github/johnynek/bazel_deps/ParseGeneratedDocTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseGeneratedDocTest.scala
@@ -20,7 +20,7 @@ class ParseGeneratedDocTest extends FunSuite {
 
     forAll(genList) { lp =>
       val output = Dependencies.normalize(lp)
-      assert(lp.size <= output.size)
+      assert(lp.size >= output.size)
       val flat1 = lp.flatMap { case (a, p) => p.flatten(a) }
       val flat2 = output.flatMap { case (a, p) => p.flatten(a) }
       assert(flat1.toSet == flat2.toSet)

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
@@ -104,87 +104,36 @@ dependencies:
 dependencies:
    com.twitter:
     chill:
-      exports:
-        - "com.esotericsoftware:kryo-shaded"
-        - "com.twitter:chill-java"
       lang: scala
       version: "0.8.4"
     chill-algebird:
-      exports:
-        - "com.esotericsoftware:kryo-shaded"
-        - "com.twitter:chill"
-        - "com.twitter:chill-java"
       lang: scala
       version: "0.8.4"
-    chill-bijection:
       exports:
-        - "com.esotericsoftware:kryo-shaded"
-        - "com.twitter:bijection-core"
         - "com.twitter:chill"
-        - "com.twitter:chill-java"
-      lang: scala
-      version: "0.8.4"
-    chill-hadoop:
-      exports:
-        - "com.esotericsoftware:kryo-shaded"
-        - "com.twitter:chill-java"
-      lang: java
-      version: "0.8.4"
-    chill-java:
-      exports:
-        - "com.esotericsoftware:kryo-shaded"
-      lang: java
-      version: "0.8.4"
     chill-scrooge:
-      exports:
-        - "com.esotericsoftware:kryo-shaded"
-        - "com.twitter:chill"
-        - "com.twitter:chill-java"
       lang: scala
       version: "0.8.4"
+      exports:
+        - "com.twitter:chill"
 """
     val output = """dependencies:
   com.twitter:
     chill:
-      exports:
-        - "com.esotericsoftware:kryo-shaded"
-        - "com.twitter:chill-java"
       lang: scala
       version: "0.8.4"
     chill-algebird:
-      exports:
-        - "com.esotericsoftware:kryo-shaded"
-        - "com.twitter:chill"
-        - "com.twitter:chill-java"
       lang: scala
       version: "0.8.4"
-    chill-bijection:
       exports:
-        - "com.esotericsoftware:kryo-shaded"
-        - "com.twitter:bijection-core"
         - "com.twitter:chill"
-        - "com.twitter:chill-java"
-      lang: scala
-      version: "0.8.4"
-    chill-hadoop:
-      exports:
-        - "com.esotericsoftware:kryo-shaded"
-        - "com.twitter:chill-java"
-      lang: java
-      version: "0.8.4"
-    chill-java:
-      exports:
-        - "com.esotericsoftware:kryo-shaded"
-      lang: java
-      version: "0.8.4"
     chill-scrooge:
-      exports:
-        - "com.esotericsoftware:kryo-shaded"
-        - "com.twitter:chill"
-        - "com.twitter:chill-java"
       lang: scala
       version: "0.8.4"
+      exports:
+        - "com.twitter:chill"
 """
+
     roundTripsTo(input, output)
   }
 }

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
@@ -21,7 +21,7 @@ class ParseTestCasesTest extends FunSuite {
 
     val model1 = Model(Dependencies.empty,Some(Replacements.empty),Some(Options(None,None,None,None,None,Some(List()),
       Some(ResolverCache.Local),Some(NamePrefix("y")))))
-    println(model1.toDoc.render(70))
+    //println(model1.toDoc.render(70))
     law(model1)
   }
 
@@ -65,17 +65,17 @@ dependencies:
   com.twitter:
     util:
       lang: scala
-      modules: [ "codec", "core", "stats" ]
+      modules: [ "cache", "collection", "events" ]
+      version: "6.29.0"
+    util-codec:
+      lang: scala
       version: "6.26.0"
-    util-cache:
+    util-core:
       lang: scala
-      version: "6.29.0"
-    util-collection:
+      version: "6.26.0"
+    util-stats:
       lang: scala
-      version: "6.29.0"
-    util-events:
-      lang: scala
-      version: "6.29.0"
+      version: "6.26.0"
 """
     roundTripsTo(input, output)
   }
@@ -123,15 +123,15 @@ dependencies:
       lang: scala
       version: "0.8.4"
     chill-algebird:
+      exports:\u0020
+        - "com.twitter:chill"
       lang: scala
       version: "0.8.4"
-      exports:
-        - "com.twitter:chill"
     chill-scrooge:
+      exports:\u0020
+        - "com.twitter:chill"
       lang: scala
       version: "0.8.4"
-      exports:
-        - "com.twitter:chill"
 """
 
     roundTripsTo(input, output)

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
@@ -98,4 +98,93 @@ dependencies:
 """
     roundTripsTo(input, output)
   }
+
+   test("Do not collapse when incompatible") {
+    val input = """
+dependencies:
+   com.twitter:
+    chill:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+        - "com.twitter:chill-java"
+      lang: scala
+      version: "0.8.4"
+    chill-algebird:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+        - "com.twitter:chill"
+        - "com.twitter:chill-java"
+      lang: scala
+      version: "0.8.4"
+    chill-bijection:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+        - "com.twitter:bijection-core"
+        - "com.twitter:chill"
+        - "com.twitter:chill-java"
+      lang: scala
+      version: "0.8.4"
+    chill-hadoop:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+        - "com.twitter:chill-java"
+      lang: java
+      version: "0.8.4"
+    chill-java:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+      lang: java
+      version: "0.8.4"
+    chill-scrooge:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+        - "com.twitter:chill"
+        - "com.twitter:chill-java"
+      lang: scala
+      version: "0.8.4"
+"""
+    val output = """dependencies:
+  com.twitter:
+    chill:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+        - "com.twitter:chill-java"
+      lang: scala
+      version: "0.8.4"
+    chill-algebird:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+        - "com.twitter:chill"
+        - "com.twitter:chill-java"
+      lang: scala
+      version: "0.8.4"
+    chill-bijection:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+        - "com.twitter:bijection-core"
+        - "com.twitter:chill"
+        - "com.twitter:chill-java"
+      lang: scala
+      version: "0.8.4"
+    chill-hadoop:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+        - "com.twitter:chill-java"
+      lang: java
+      version: "0.8.4"
+    chill-java:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+      lang: java
+      version: "0.8.4"
+    chill-scrooge:
+      exports:
+        - "com.esotericsoftware:kryo-shaded"
+        - "com.twitter:chill"
+        - "com.twitter:chill-java"
+      lang: scala
+      version: "0.8.4"
+"""
+    roundTripsTo(input, output)
+  }
 }

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTestUtil.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTestUtil.scala
@@ -25,6 +25,9 @@ object ParseTestUtil extends FunSuite {
     val mod = decode(input)
     val modStr = mod.toDoc.render(70)
     //assert(decode(modStr) === mod)
+    // println(input)
+    // println("------")
+    // println(modStr)
     assert(modStr === output)
   }
 


### PR DESCRIPTION
@ianoc-stripe in #84 found an example of the minimization algorithm deleting entries.

I have reworked the algorithm again to be more principled, but also exponential in complexity. The exponential part only runs for sets of dependencies that share a common prefix in maven group and in artifact, so in practice that is small enough that it is very fast. But if you have 100 modules in a single artifact each with different versions, this algorithm might fall over.

It is only used in format now, so even if we hit such a corner case, users can work around by not formatting (which triggers the minimization).