### PR TITLE
add `--check-only` flag to `generate` command (fixes #85)

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/Commands.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Commands.scala
@@ -9,7 +9,7 @@ import java.nio.file.Path
 sealed abstract class Command
 
 object Command {
-  case class Generate(repoRoot: Path, depsFile: String, shaFile: String) extends Command {
+  case class Generate(repoRoot: Path, depsFile: String, shaFile: String, checkOnly: Boolean) extends Command {
     def absDepsFile: File =
       new File(repoRoot.toFile, depsFile)
 
@@ -35,7 +35,11 @@ object Command {
       metavar = "sha-file",
       help = "relative path to the sha lock file (usually called workspace.bzl).")
 
-    (repoRoot |@| depsFile |@| shaFile).map(Generate(_, _, _))
+    val checkOnly = Opts.flag(
+      "check-only",
+      help = "if set, the generated files are checked against the existing files but are not written; exits 0 if the files match").orFalse
+
+    (repoRoot |@| depsFile |@| shaFile |@| checkOnly).map(Generate(_, _, _, _))
   }
 
   case class FormatDeps(deps: Path, overwrite: Boolean) extends Command

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -547,7 +547,7 @@ case class Dependencies(toMap: Map[MavenGroup, Map[ArtifactOrProject, ProjectRec
         case Nil =>
           ap.get(a).map(_.allDependencies(g, a)) match {
             case Some(h :: Nil) => Some(h)
-            case other => println(other); None // 0 or more than one
+            case other => None // 0 or more than one
           }
         case parts =>
           // This can be split, but may not be:

--- a/src/scala/com/github/johnynek/bazel_deps/IO.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/IO.scala
@@ -7,6 +7,7 @@ import cats.free.Free.liftF
 import java.io.{File, FileOutputStream, IOException}
 import java.nio.file.{Files, SimpleFileVisitor, FileVisitResult, Path => JPath}
 import java.nio.file.attribute.BasicFileAttributes
+import java.util.Arrays
 import scala.util.{ Failure, Success, Try }
 
 import cats.implicits._
@@ -16,17 +17,23 @@ import cats.implicits._
  */
 
 object IO {
+  val charset = "UTF-8"
+  val pathSeparator = File.separator
+
   case class Path(parts: List[String]) {
     def child(p: String): Path = Path(parts ++ List(p))
     def parent: Path = Path(parts.dropRight(1))
     def sibling(p: String): Path = Path(parts.dropRight(1) ++ List(p))
+    def asString: String = parts.mkString(pathSeparator)
   }
 
   def path(s: String): Path =
-    Path(s.split("/").toList match {
+    Path(s.split(pathSeparator).toList match {
       case "" :: rest => rest
       case list => list
     })
+
+  case class FileComparison(path: Path, ok: Boolean)
 
   sealed abstract class Ops[+T]
   case class Exists(path: Path) extends Ops[Boolean]
@@ -39,6 +46,7 @@ object IO {
    */
   case class WriteFile(f: Path, data: Eval[String]) extends Ops[Unit]
   case class Failed(err: Throwable) extends Ops[Nothing]
+  case class ReadFile(path: Path) extends Ops[Option[String]]
 
   type Result[T] = Free[Ops, T]
 
@@ -68,6 +76,14 @@ object IO {
 
   def writeUtf8(f: Path, s: => String): Result[Unit] =
     liftF[Ops, Unit](WriteFile(f, Eval.always(s)))
+
+  // Reads the contents of `f`, returning None if file doesn't exist
+  def readUtf8(f: Path): Result[Option[String]] =
+    liftF[Ops, Option[String]](ReadFile(f))
+
+  // Checks if the path at `f` exists and has the content `s`
+  def compare(f: Path, s: => String): Result[FileComparison] =
+    readUtf8(f).map { contents => FileComparison(f, contents.map(s == _).getOrElse(false)) }
 
   def run[A](io: Result[A], root: File)(resume: A => Unit): Unit =
     io.foldMap(IO.fileSystemExec(root)) match {
@@ -107,8 +123,12 @@ object IO {
       case WriteFile(f, d) =>
         Try {
           val os = new FileOutputStream(fileFor(f))
-          try os.write(d.value.getBytes("UTF-8")) finally { os.close() }
+          try os.write(d.value.getBytes(charset)) finally { os.close() }
         }
+      case ReadFile(f) => Try({
+        val ff = fileFor(f)
+        if (ff.exists) Some(new String(Files.readAllBytes(ff.toPath), charset)) else None
+      })
       case Failed(err) => Failure(err)
     }
   }


### PR DESCRIPTION
If present, this flag causes the generate command to resolve all dependencies as usual, but does not write the files. Instead, it checks that each generated file on disk has the expected content.  If any files do not match the expected content, they are logged and bazel-deps exits with code 2; bazel-deps exits 0 if everything matches.