### PR TITLE
add `--buildifier` option to `generate` to format BUILD files (fixes #73)

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/Commands.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Commands.scala
@@ -9,7 +9,7 @@ import java.nio.file.Path
 sealed abstract class Command
 
 object Command {
-  case class Generate(repoRoot: Path, depsFile: String, shaFile: String, checkOnly: Boolean) extends Command {
+  case class Generate(repoRoot: Path, depsFile: String, shaFile: String, buildifier: Option[String], checkOnly: Boolean) extends Command {
     def absDepsFile: File =
       new File(repoRoot.toFile, depsFile)
 
@@ -35,11 +35,16 @@ object Command {
       metavar = "sha-file",
       help = "relative path to the sha lock file (usually called workspace.bzl).")
 
+    val buildifier = Opts.option[String](
+      "buildifier",
+      metavar = "buildifier",
+      help = "absolute path to buildifier binary, which will be called to format each generated BUILD file").orNone
+
     val checkOnly = Opts.flag(
       "check-only",
       help = "if set, the generated files are checked against the existing files but are not written; exits 0 if the files match").orFalse
 
-    (repoRoot |@| depsFile |@| shaFile |@| checkOnly).map(Generate(_, _, _, _))
+    (repoRoot |@| depsFile |@| shaFile |@| buildifier |@| checkOnly).map(Generate(_, _, _, _, _))
   }
 
   case class FormatDeps(deps: Path, overwrite: Boolean) extends Command


### PR DESCRIPTION
If present, the contents of each generated BUILD file will be formatted before writing to disk (or checking against the existing files).  Formatting takes just a couple milliseconds per file.

I think this approach gives the best flexibility of not adding a hard dependency on the buildifier.  Simply running the buildifier after generate in a wrapper script isn't sufficient, because the in-memory versions used by `--check-only` need to be formatted like the files on disk.  This covers both.