### PR TITLE
Support Bazel 0.7.0 with rules_scala.

### DIFF
--- a/.bazel-installer-linux-x86_64.sh.sha256
+++ b/.bazel-installer-linux-x86_64.sh.sha256
@@ -1,1 +1,1 @@
-6e30f1aa3dcbb9c022251e60ac445244f66535ea627afd1780eafe2de19dab8f  bazel-0.6.0-installer-linux-x86_64.sh
+e72baaef66b09e5f765c0c7d3c216cda0c8c48368524605705cfe14a584e9942  bazel-0.7.0-installer-linux-x86_64.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ jdk:
   - oraclejdk8
 
 before_install:
-  - wget 'https://github.com/bazelbuild/bazel/releases/download/0.6.0/bazel-0.6.0-installer-linux-x86_64.sh'
+  - wget 'https://github.com/bazelbuild/bazel/releases/download/0.7.0/bazel-0.7.0-installer-linux-x86_64.sh'
   - sha256sum -c .bazel-installer-linux-x86_64.sh.sha256
-  - chmod +x bazel-0.6.0-installer-linux-x86_64.sh
-  - ./bazel-0.6.0-installer-linux-x86_64.sh --user
+  - chmod +x bazel-0.7.0-installer-linux-x86_64.sh
+  - ./bazel-0.7.0-installer-linux-x86_64.sh --user
   - cp .bazelrc.travis .bazelrc
 
 script:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ workspace(name = "com_github_johnynek_bazel_deps")
 git_repository(
     name = "io_bazel_rules_scala",
     remote = "git://github.com/bazelbuild/rules_scala",
-    commit = "0bac7fe86fdde1cfba3bb2c8a04de5e12de47bcd" # update this as needed
+    commit = "388a2585f45dff804d006b0e81e1b1a1c60578bc" # update this as needed
 )
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()


### PR DESCRIPTION
The latest version of `rules_scala` supports Bazel 0.7.0. 

The `master` version of `bazel-deps` fails with Bazel 0.7.0:

```
gdonovan@3983:~/development/bazel-deps (master)$ bazel build //... && bazel test --test_output errors //... && bazel build src/scala/com/github/johnynek/bazel_deps/parseproject_deploy.jar && ./gen_maven_deps.sh generate -r `pwd` -s 3rdparty/workspace.bzl -d dependencies.yaml && git diff --exit-code
ERROR: /Users/gdonovan/development/bazel-deps/3rdparty/jvm/org/typelevel/BUILD:87:1: in scala_library rule //3rdparty/jvm/org/typelevel:macro_compat: 
Traceback (most recent call last):
        File "/Users/gdonovan/development/bazel-deps/3rdparty/jvm/org/typelevel/BUILD", line 87
                scala_library(name = 'macro_compat')
        File "/private/var/tmp/_bazel_gdonovan/6fcac0fd900f6c0d2558c506b5c338d2/external/io_bazel_rules_scala/scala/scala.bzl", line 662, in _scala_library_impl
                _lib(ctx, True)
        File "/private/var/tmp/_bazel_gdonovan/6fcac0fd900f6c0d2558c506b5c338d2/external/io_bazel_rules_scala/scala/scala.bzl", line 633, in _lib
                create_java_provider(ctx, scalaattr, jars.transitive_comp...)
        File "/private/var/tmp/_bazel_gdonovan/6fcac0fd900f6c0d2558c506b5c338d2/external/io_bazel_rules_scala/scala/scala.bzl", line 566, in create_java_provider
                java_common.create_provider(ctx.actions, java_toolchain = ctx...., <4 more arguments>)
Output artifact 'external/org_typelevel_macro_compat_2_11/jar/macro-compat_2.11-1.1.1-ijar.jar' not under package directory '3rdparty/jvm/org/typelevel' for target '//3rdparty/jvm/org/typelevel:macro_compat'.
ERROR: Analysis of target '//3rdparty/jvm/com/github/mpilquist:simulacrum' failed; build aborted: Analysis of target '//3rdparty/jvm/org/typelevel:macro_compat' failed; build aborted.
INFO: Elapsed time: 3.466s
```

This is part of the fix for [BUILD_file_generator#25](https://github.com/bazelbuild/BUILD_file_generator/issues/25).