### PR TITLE
Support annotation processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,42 @@ Each group id can only appear once, so you should collocate dependencies by grou
 we are using does not fail on duplicate keys, it just takes the last one, so watch out. It would be good
 to fix that, but writing a new yaml parser is out of scope.
 
+A target may also optionally add `processorClasses` to a dependency. This is for [annotation processors](https://docs.oracle.com/javase/8/docs/api/javax/annotation/processing/Processor.html).
+`bazel-deps` will generate a `java_library` and a `java_plugin` for each annotation processor defined. For example, we can define Google's auto-value annotation processor via:
+```
+dependencies:
+  com.google.auto.value:
+    auto-value:
+      version: "1.5"
+      lang: java
+      processorClasses: ["com.google.auto.value.processor.AutoValueProcessor"]
+```
+This will yield the following:
+```
+java_library(
+    name = "auto_value",
+    exported_plugins = [
+        ":auto_value_plugin",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+    exports = [
+        "//external:jar/com/google/auto/value/auto_value",
+    ],
+)
+
+java_plugin(
+    name = "auto_value_plugin",
+    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
+    deps = [
+        "//external:jar/com/google/auto/value/auto_value",
+    ],
+)
+``` 
+If there is only a single `processorClasses` defined, the `java_plugin` rule is named `<java_library_name>_plugin`. If there are multiple
+`processorClasses` defined, each one is named `<java_library_name>_plugin_<processor_class_to_snake_case>`.
+
 ### <a name="options">Options</a>
 In the options we set:
 

--- a/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
@@ -6,6 +6,7 @@ import io.circe.generic.auto
 
 object Decoders {
   implicit val versionDecoder: Decoder[Version] = stringWrapper(Version(_))
+  implicit val processorClassDecoder: Decoder[ProcessorClass] = stringWrapper(ProcessorClass(_))
   implicit val subprojDecoder: Decoder[Subproject] = stringWrapper(Subproject(_))
   implicit val dirnameDecoder: Decoder[DirectoryName] = stringWrapper(DirectoryName(_))
   implicit val targetDecoder: Decoder[BazelTarget] = stringWrapper(BazelTarget(_))
@@ -129,4 +130,4 @@ object Decoders {
 
   private def stringWrapper[T](fn: String => T): Decoder[T] =
     Decoder.decodeString.map(fn)
-}
+  }

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -176,6 +176,7 @@ case class MavenServer(id: String, contentType: String, url: String) {
       List(("id", quoteDoc(id)), ("type", quoteDoc(contentType)), ("url", Doc.text(url))))
 }
 case class ResolvedSha1Value(sha1Value: Sha1Value, serverId: String)
+case class ProcessorClass(asString: String)
 
 object Version {
   private def isNum(c: Char): Boolean =
@@ -276,7 +277,7 @@ case class MavenCoordinate(group: MavenGroup, artifact: MavenArtifactId, version
   def toDependencies(l: Language): Dependencies =
     Dependencies(Map(group ->
       Map(ArtifactOrProject(artifact.asString) ->
-        ProjectRecord(l, Some(version), None, None, None))))
+        ProjectRecord(l, Some(version), None, None, None, None))))
 }
 
 object MavenCoordinate {
@@ -412,12 +413,13 @@ case class ProjectRecord(
   version: Option[Version],
   modules: Option[Set[Subproject]],
   exports: Option[Set[(MavenGroup, ArtifactOrProject)]],
-  exclude: Option[Set[(MavenGroup, ArtifactOrProject)]]) {
+  exclude: Option[Set[(MavenGroup, ArtifactOrProject)]],
+  processorClasses: Option[Set[ProcessorClass]]) {
 
 
   // Cache this
   override lazy val hashCode: Int =
-    (lang, version, modules, exports, exports).hashCode
+    (lang, version, modules, exports, exclude, processorClasses).hashCode
 
   def flatten(ap: ArtifactOrProject): List[(ArtifactOrProject, ProjectRecord)] =
     getModules match {
@@ -493,7 +495,10 @@ case class ProjectRecord(
       exports.toList.map { ms =>
         ("exports", exportsDoc(ms)) },
       exclude.toList.map { ms =>
-        ("exclude", exportsDoc(ms)) })
+        ("exclude", exportsDoc(ms)) },
+      processorClasses.toList.map { pcs =>
+        ("processorClasses", list(pcs.toList.sortBy(_.asString)) { pc => quoteDoc(pc.asString) }) }
+      )
       .flatten
       .sortBy(_._1)
     packedYamlMap(record)

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -491,13 +491,13 @@ case class ProjectRecord(
     val record = List(List(("lang", Doc.text(lang.asString))),
       version.toList.map { v => ("version", quoteDoc(v.asString)) },
       modules.toList.map { ms =>
-        ("modules", list(ms.toList.sortBy(_.asString)) { m => quoteDoc(m.asString) }) },
+        ("modules", list(ms.map(_.asString).toList.sorted)(quoteDoc)) },
       exports.toList.map { ms =>
         ("exports", exportsDoc(ms)) },
       exclude.toList.map { ms =>
         ("exclude", exportsDoc(ms)) },
       processorClasses.toList.map { pcs =>
-        ("processorClasses", list(pcs.toList.sortBy(_.asString)) { pc => quoteDoc(pc.asString) }) }
+        ("processorClasses", list(pcs.map(_.asString).toList.sorted)(quoteDoc)) }
       )
       .flatten
       .sortBy(_._1)

--- a/src/scala/com/github/johnynek/bazel_deps/Target.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Target.scala
@@ -109,14 +109,14 @@ case class Target(
       sortKeys(Doc.text("java_plugin"), getPluginTargetName(pcs, pc), List(
         "deps" -> labelList(exports),
         "processor_class" -> quote(pc.asString),
-        visibility(quote)
+        visibility()
       )) + Doc.line
 
-    def visibility[T](show: T => Doc): (String, Doc) =
+    def visibility(): (String, Doc) =
       "visibility" -> renderList(Doc.text("["), List("//visibility:public"), Doc.text("]"))(quote)
 
     sortKeys(targetType, name.name, List(
-      visibility(quote),
+      visibility(),
       "deps" -> labelList(deps),
       "srcs" -> sources.render,
       "exports" -> labelList(exports),

--- a/src/scala/com/github/johnynek/bazel_deps/Target.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Target.scala
@@ -54,7 +54,8 @@ case class Target(
   deps: Set[Label] = Set.empty,
   sources: Target.SourceList = Target.SourceList.Empty,
   exports: Set[Label] = Set.empty,
-  runtimeDeps: Set[Label] = Set.empty) {
+  runtimeDeps: Set[Label] = Set.empty,
+  processorClasses: Set[ProcessorClass] = Set.empty) {
 
   def toDoc: Doc = {
     import Target._
@@ -76,25 +77,52 @@ case class Target(
 
     val targetType = Doc.text(s"${langName}_${kind}")
 
-    def sortKeys(items: List[(String, Doc)]): Doc = {
+    def sortKeys(tt: Doc, name: String, items: List[(String, Doc)]): Doc = {
       // everything has a name
-      val nm = ("name", quote(name.name))
+      val nm = ("name", quote(name))
       implicit val ordDoc: Ordering[Doc] = Ordering.by { d: Doc => d.renderWideStream.mkString }
       val sorted = items.collect { case (s, d) if !(d.isEmpty) => (s, d) }.sorted
 
-      renderList(targetType + Doc.text("("), nm :: sorted, Doc.text(")")) { case (k, v) =>
+      renderList(tt + Doc.text("("), nm :: sorted, Doc.text(")")) { case (k, v) =>
         k +: " = " +: v
-      } + Doc.line.repeat(2)
+      } + Doc.line
     }
 
     def labelList(ls: Set[Label]): Doc =
       renderList(Doc.text("["), ls.toList.map(_.asStringFrom(name.path)).sorted, Doc.text("]"))(quote)
 
-    sortKeys(List(
+    def renderExportedPlugins(pcs: Set[ProcessorClass]): Doc = {
+      renderList(Doc.text("["), pcs.toList.map(pc => ":" + getPluginTargetName(pcs, pc)).sorted, Doc.text("]"))(quote)
+    }
+    def getPluginTargetName(pcs: Set[ProcessorClass], processorClass: ProcessorClass) =
+      if (pcs.size == 1) s"${name.name}_plugin"
+      else {
+        val fqnToSnakeCase = camel2Underscore(shortName(processorClass.asString))
+        s"${name.name}_plugin_$fqnToSnakeCase"
+      }
+    def camel2Underscore(text: String) = text.drop(1).foldLeft(text.headOption.map(_.toLower + "") getOrElse "") {
+      case (acc, c) if c.isUpper => acc + "_" + c.toLower
+      case (acc, c) if c == '$' => acc
+      case (acc, c) => acc + c
+    }
+    def shortName(fqn: String) = if (fqn.contains(".")) fqn.substring(fqn.lastIndexOf('.') + 1) else fqn
+    def renderPlugins(pcs: Set[ProcessorClass], exports: Set[Label]): Doc = {
+      if (pcs.isEmpty) Doc.empty
+      else processorClasses.toList.map(renderPlugin(pcs, _, exports)).reduce((d1, d2) => d1 + d2)
+    }
+    def renderPlugin(pcs: Set[ProcessorClass], pc: ProcessorClass, exports: Set[Label]): Doc =
+      sortKeys(Doc.text("java_plugin"), getPluginTargetName(pcs, pc), List(
+        "deps" -> labelList(exports),
+        "processor_class" -> quote(pc.asString)
+      )) + Doc.line
+
+    sortKeys(targetType, name.name, List(
       "visibility" -> renderList(Doc.text("["), List("//visibility:public"), Doc.text("]"))(quote),
       "deps" -> labelList(deps),
       "srcs" -> sources.render,
       "exports" -> labelList(exports),
-      "runtime_deps" -> labelList(runtimeDeps)))
+      "runtime_deps" -> labelList(runtimeDeps),
+      "exported_plugins" -> renderExportedPlugins(processorClasses)
+    )) + renderPlugins(processorClasses, exports) + Doc.line
   }
 }

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -213,10 +213,16 @@ object Writer {
         Target(lang,
           Label.localTarget(pathInRoot, u, lang),
           exports = exports ++ uvexports,
-          runtimeDeps = runtime_deps -- uvexports)
+          runtimeDeps = runtime_deps -- uvexports,
+          processorClasses = getProcessorClasses(u))
       })
       def targetFor(u: UnversionedCoordinate): Target =
         replacedTarget(u).getOrElse(coordToTarget(u))
+      def getProcessorClasses(u: UnversionedCoordinate): Set[ProcessorClass] = {
+        val m: Option[Map[ArtifactOrProject, ProjectRecord]] = model.dependencies.toMap.get(u.group)
+        val projectRecord: Option[ProjectRecord] = m.flatMap(_.get(ArtifactOrProject(u.artifact.asString)))
+        projectRecord.flatMap(_.processorClasses).getOrElse(Set.empty)
+      }
 
       Right(allUnversioned.iterator.map(targetFor).toList)
     }

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -218,11 +218,11 @@ object Writer {
       })
       def targetFor(u: UnversionedCoordinate): Target =
         replacedTarget(u).getOrElse(coordToTarget(u))
-      def getProcessorClasses(u: UnversionedCoordinate): Set[ProcessorClass] = {
-        val m: Option[Map[ArtifactOrProject, ProjectRecord]] = model.dependencies.toMap.get(u.group)
-        val projectRecord: Option[ProjectRecord] = m.flatMap(_.get(ArtifactOrProject(u.artifact.asString)))
-        projectRecord.flatMap(_.processorClasses).getOrElse(Set.empty)
-      }
+      def getProcessorClasses(u: UnversionedCoordinate): Set[ProcessorClass] =
+        (for {
+          m <- model.dependencies.toMap.get(u.group)
+          projectRecord <- m.get(ArtifactOrProject(u.artifact.asString))
+        } yield projectRecord.processorClasses).flatten.getOrElse(Set.empty)
 
       Right(allUnversioned.iterator.map(targetFor).toList)
     }

--- a/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
@@ -163,6 +163,7 @@ object Tool {
             Some(Version(d.version)),
             None,
             None,
+            None,
             None))
       }
       .toList

--- a/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
@@ -22,7 +22,8 @@ object ModelGenerators {
     m <- Gen.option(Gen.listOfN(sub, subprojGen).map(_.toSet))
     exports <- Gen.option(Gen.listOfN(exp, join(mavenGroupGen, artifactOrProjGen)).map(_.toSet))
     exclude <- Gen.option(Gen.listOfN(exc, join(mavenGroupGen, artifactOrProjGen)).map(_.toSet))
-  } yield ProjectRecord(lang, v, m, exports, exclude)
+    processorClasses <- Gen.option(Gen.listOfN(5, ProcessorClass("")).map(_.toSet)) // TODO(ggg)
+  } yield ProjectRecord(lang, v, m, exports, exclude, processorClasses)
 
   def depGen(o: Options): Gen[Dependencies] = {
     val (l1, ls) = o.getLanguages match {

--- a/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
@@ -19,10 +19,11 @@ object ModelGenerators {
     sub <- Gen.choose(0, 6)
     exp <- Gen.choose(0, 3)
     exc <- Gen.choose(0, 3)
+    pcs <- Gen.choose(0, 2)
     m <- Gen.option(Gen.listOfN(sub, subprojGen).map(_.toSet))
     exports <- Gen.option(Gen.listOfN(exp, join(mavenGroupGen, artifactOrProjGen)).map(_.toSet))
     exclude <- Gen.option(Gen.listOfN(exc, join(mavenGroupGen, artifactOrProjGen)).map(_.toSet))
-    processorClasses <- Gen.option(Gen.listOfN(5, ProcessorClass("")).map(_.toSet)) // TODO(ggg)
+    processorClasses <- Gen.option(Gen.listOfN(pcs, processorClassGen).map(_.toSet))
   } yield ProjectRecord(lang, v, m, exports, exclude, processorClasses)
 
   def depGen(o: Options): Gen[Dependencies] = {
@@ -73,4 +74,11 @@ object ModelGenerators {
     d <- depGen(opts)
     r <- Gen.option(replacementGen(opts.getLanguages.toList))
   } yield Model(d, r, o)
+
+  val processorClassGen: Gen[ProcessorClass] =
+    for {
+      partLen <- Gen.choose(1,10)
+      numParts <- Gen.choose(1,6)
+      s <- Gen.listOfN(numParts, Gen.listOfN(partLen, Gen.alphaChar).map(_.mkString)).map(_.mkString("", ".", ""))
+    } yield ProcessorClass(s)
 }

--- a/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
@@ -33,7 +33,7 @@ class ModelTest extends FunSuite {
     val lang = Language.Scala.default
     val deps = Dependencies(Map(
       MavenGroup("com.twitter") -> Map(
-        ArtifactOrProject("finagle") -> ProjectRecord(lang, Some(Version("0.1")), Some(Set(Subproject(""), Subproject("core"))), None, None)
+        ArtifactOrProject("finagle") -> ProjectRecord(lang, Some(Version("0.1")), Some(Set(Subproject(""), Subproject("core"))), None, None, None)
       )
     ))
 

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
@@ -28,6 +28,7 @@ class ParseTest extends FunSuite {
                 Some(Version("0.16.0")),
                 Some(Set("core", "args", "date").map(Subproject(_))),
                 None,
+                None,
                 None))),
           None,
           None)))
@@ -55,6 +56,7 @@ class ParseTest extends FunSuite {
                 Language.Scala(Version("2.11.7"), true),
                 Some(Version("0.16.0")),
                 Some(Set("core", "args", "date").map(Subproject(_))),
+                None,
                 None,
                 None))),
           None,
@@ -92,8 +94,8 @@ class ParseTest extends FunSuite {
                 Some(Version("0.16.0")),
                 Some(Set("", "core", "args", "date").map(Subproject(_))),
                 None,
-                None
-                ))),
+                None,
+                None))),
           None,
           Some(
             Options(
@@ -108,6 +110,32 @@ class ParseTest extends FunSuite {
 
     assert(MavenArtifactId(ArtifactOrProject("a"), Subproject("")).asString === "a")
     assert(MavenArtifactId(ArtifactOrProject("a"), Subproject("b")).asString === "a-b")
+  }
+
+
+  test("parse a file with an annotationProcessor defined") {
+    val str = """dependencies:
+                |  com.google.auto.value:
+                |    auto-value:
+                |      version: "1.5"
+                |      lang: java
+                |      processorClasses: ["com.google.auto.value.processor.AutoValueProcessor"]
+                |""".stripMargin('|')
+
+    assert(Decoders.decodeModel(Yaml, str) ==
+      Right(Model(
+        Dependencies(
+          MavenGroup("com.google.auto.value") ->
+            Map(ArtifactOrProject("auto-value") ->
+              ProjectRecord(
+                Language.Java,
+                Some(Version("1.5")),
+                None,
+                None,
+                None,
+                Some(Set(ProcessorClass("com.google.auto.value.processor.AutoValueProcessor")))))),
+        None,
+        None)))
   }
   /*
    * TODO make this test pass

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
@@ -13,7 +13,7 @@ class ParseTestCasesTest extends FunSuite {
       Map(
         MavenGroup("n2rr") ->
           Map(
-            ArtifactOrProject("zmup") -> ProjectRecord(Java,Some(Version("019")),Some(Set(Subproject("wcv"))),Some(Set((MavenGroup("j9szw4"),ArtifactOrProject("i")))),None)
+            ArtifactOrProject("zmup") -> ProjectRecord(Java,Some(Version("019")),Some(Set(Subproject("wcv"))),Some(Set((MavenGroup("j9szw4"),ArtifactOrProject("i")))),None,None)
           )
         )),Some(Replacements(Map())),None)
 


### PR DESCRIPTION
See discussion in https://github.com/johnynek/bazel-deps/issues/62

I added support for multiple annotation processors per `java_library`, as I think it is a possible (though admittedly rare) requirement.

There are a couple TODOs and I would like to add test coverage to the new functions in `Target` but I wanted to start a PR to see if this was directionally correct.