### PR TITLE
Export target in replacement.

### DIFF
--- a/3rdparty/jvm/org/scala_lang/BUILD
+++ b/3rdparty/jvm/org/scala_lang/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")
-scala_import(
+scala_library(
     name = "scala_compiler",
-    jars = [
+    exports = [
         "@scala//:scala-compiler"
     ],
     visibility = [
@@ -11,9 +11,9 @@ scala_import(
 
 
 
-scala_import(
+scala_library(
     name = "scala_library",
-    jars = [
+    exports = [
         "@scala//:scala-library"
     ],
     visibility = [
@@ -23,9 +23,9 @@ scala_import(
 
 
 
-scala_import(
+scala_library(
     name = "scala_reflect",
-    jars = [
+    exports = [
         "@scala//:scala-reflect"
     ],
     visibility = [

--- a/3rdparty/jvm/org/scala_lang/modules/BUILD
+++ b/3rdparty/jvm/org/scala_lang/modules/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")
-scala_import(
+scala_library(
     name = "scala_parser_combinators",
-    jars = [
+    exports = [
         "@scala//:scala-parser-combinators"
     ],
     visibility = [
@@ -11,9 +11,9 @@ scala_import(
 
 
 
-scala_import(
+scala_library(
     name = "scala_xml",
-    jars = [
+    exports = [
         "@scala//:scala-xml"
     ],
     visibility = [

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -197,10 +197,10 @@ object Writer {
                 jars = Set.empty)
             case _: Language.Scala =>
               Target(lang,
-                kind = Target.Import,
+                kind = Target.Library,
                 name = Label.localTarget(pathInRoot, u, lang),
-                exports = Set.empty,
-                jars = Set(lab))
+                exports = Set(lab),
+                jars = Set.empty)
           }
 
         }


### PR DESCRIPTION
This fixes https://github.com/johnynek/bazel-deps/issues/103 by exporting the replacement target instead of including it as a jar.

A snippet of a diff after running this version of `bazel-deps` in our monorepo:
```
diff --git a/3rdparty/jvm/io/getquill/BUILD b/3rdparty/jvm/io/getquill/BUILD
index 8dc63b848..12cbda461 100644
--- a/3rdparty/jvm/io/getquill/BUILD
+++ b/3rdparty/jvm/io/getquill/BUILD
@@ -3,20 +3,20 @@ load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")
 
 scala_import(
     name = "quill_cassandra",
-    jars = [
-        "//3rdparty/jvm_manual/io/getquill:quill_cassandra",
-    ],
     visibility = [
         "//visibility:public",
     ],
+    exports = [
+        "//3rdparty/jvm_manual/io/getquill:quill_cassandra",
+    ],
 )
 
 scala_import(
     name = "quill_core",
-    jars = [
-        "//3rdparty/jvm_manual/io/getquill:quill_core",
-    ],
     visibility = [
         "//visibility:public",
     ],
+    exports = [
+        "//3rdparty/jvm_manual/io/getquill:quill_core",
+    ],
 )
```