### PR TITLE
Fixes #112 -- build broken under bazel 0.10.0

### DIFF
--- a/3rdparty/manual/BUILD.decline
+++ b/3rdparty/manual/BUILD.decline
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+
 scala_library(
   name = "decline",
   srcs = glob(["src/main/**/*.scala"]),

--- a/3rdparty/manual/BUILD.paiges
+++ b/3rdparty/manual/BUILD.paiges
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+
 scala_library(
   name = "paiges",
   srcs = glob(["core/src/main/**/*.scala"]),


### PR DESCRIPTION
This fixes the build w/ bazel 0.10.0. Bazel commit https://github.com/bazelbuild/bazel/commit/c93ef7ba6443d7546294eacfe9d21573a11aad70 changed the behavior of prelude_bazel such that it doesn't apply to dependency workspaces -- those workspaces use their own prelude_bazel if they have one.