### PR TITLE
Simplify usage instructions to use bazel run on a top level alias

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,5 @@
+# Top level Bazel run alias for parseproject
+alias(
+    name = "parse",
+    actual = "//src/scala/com/github/johnynek/bazel_deps:parseproject"
+)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ support.
 Run parseproject on your project yaml file. For instance, this project is setup with:
 
 ```bash
-bazel build src/scala/com/github/johnynek/bazel_deps:parseproject_deploy.jar
-./gen_maven_deps.sh generate -r `pwd` -s 3rdparty/workspace.bzl -d dependencies.yaml
+bazel run //:parse -- generate -r `pwd` -s 3rdparty/workspace.bzl -d dependencies.yaml
 ```
+
 We give three arguments: the path to the file we will include in our workspace. The path to the root
 of our bazel repo. The path to the dependencies file. You can also run with `--help`.
 


### PR DESCRIPTION
Instead of running `gen_maven_deps.sh`, `bazel run` will build the necessary deps and run `parseproject` as though it was a deploy jar (but not really, it's a stub script that knows where the runfiles are). This removes the need for a separate build step and a shell script runner. 

I've also created a top level alias for `parseproject` to not have to refer a deeply nested target. I think this makes the final command simpler: `bazel run //:parse -- ...args`