### PR TITLE
Fix SHA1 check

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/Resolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Resolver.scala
@@ -126,10 +126,11 @@ class Resolver(servers: List[MavenServer], resolverCachePath: Path) {
           .head
           .trim
           .toLowerCase
-      val asInt = scala.math.BigInt(hexString, 16)
-      if (asInt.toByteArray.size == 20) Success(Sha1Value(hexString))
-      else Failure(
-        new Exception(s"string: $hexString, not a valid SHA1 (bitsize ${asInt.toByteArray.size * 8} != 160"))
+      if (hexString.length == 40 && hexString.matches("[0-9A-Fa-f]*")) {
+        Success(Sha1Value(hexString))
+      } else {
+        Failure(new Exception(s"string: $hexString, not a valid SHA1"))
+      }
     }
 
   private def computeShaOf(f: File): Try[Sha1Value] = Try {


### PR DESCRIPTION
In Resolver.scala a SHA1 value was validated using:

  scala.math.BigInt(hexString,16).asByteArray.length == 20.

This does not work if the SHA1 value starts with a high order bit, i.e, 8-f.
In that case the byte array representation of the BigInt has an additional sign
byte and the length of the byte array is 21.

The fix is to switch from using BigInt for validation of SHA1 values to a
simple syntactic check on the string, i.e., each character is in [0-9A-Fa-f]
and the lengt of the string is 40.

This fixes #120.