### PR TITLE
Add .bazelproject file for easy IntelliJ setup

### DIFF
--- a/ij.bazelproject
+++ b/ij.bazelproject
@@ -1,0 +1,13 @@
+directories:
+  .
+
+targets:
+  //src/...:all
+  //test/...:all
+  //3rdparty/...:all
+
+test_sources:
+  test/*
+
+additional_languages:
+  scala


### PR DESCRIPTION
One click setup for IntelliJ developers with the Bazel plugin using "Import project view file" option.