### PR TITLE
Generate a docker image 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,3 +32,22 @@ new_git_repository(
 )
 
 bind(name = 'io_bazel_rules_scala/dependency/scalatest/scalatest', actual = '//3rdparty/jvm/org/scalatest')
+
+git_repository(
+    name = "io_bazel_rules_docker",
+    remote = "https://github.com/bazelbuild/rules_docker.git",
+    tag = "v0.4.0",
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+    container_repositories = "repositories",
+)
+
+load(
+    "@io_bazel_rules_docker//scala:image.bzl",
+    _scala_image_repos = "repositories",
+)
+
+_scala_image_repos()

--- a/src/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/src/scala/com/github/johnynek/bazel_deps/BUILD
@@ -100,6 +100,29 @@ scala_binary(name = "parseproject",
              main_class = "com.github.johnynek.bazel_deps.ParseProject",
              visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//scala:image.bzl", "scala_image")
+
+scala_image(name = "bazel-deps",
+             srcs = ["ParseProject.scala"],
+             deps = [
+                 ":makedeps",
+                 ":commands",
+                 ],
+             main_class = "com.github.johnynek.bazel_deps.ParseProject",
+             visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_docker//container:push.bzl", "container_push")
+container_push(
+    name = "docker_namtzigla",
+    registry = "index.docker.io",
+    image = ":bazel-deps",
+    format = "Docker",
+    repository = "namtzigla/bazel-deps",
+    tag = "latest",
+
+)
+
+
 scala_library(name = "circeyaml",
               srcs = ["CirceYaml.scala"],
               deps = [


### PR DESCRIPTION
Hi,

Great job on this project, is probably the best dep manager for bazel so far.

I have a simple proposal, generate a docker image! When I tried to integrate the project into our existing bazel projects I've found that is pretty complicated especially when I have scala 2.12 projects, so I've come up with a simple idea, I've generated a docker image that will contain bazel-deps build that will improve the usability. The only thing that need to be executed is a simple docker command like this:

```
 docker run -v (pwd):/project -it namtzigla/bazel-deps generate -r /project -s 3rdparty/workspace.bzl -d dependencies.yaml
```
This PR try to push the image into my docker account, so probably you will want to change this, but I think is a good starting point.

thanks