### PR TITLE
Add the ability to add licenses tags to generated BUILD files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ In the options we set:
   output_base`)
 * namePrefix: a string added to the generated workspace names, to avoid conflicts.  The external repository names and
   binding targets of each dependency are prefixed.
+* licenses: a set of strings added a licenses rule to each generated bazel target.  Required by
+  bazel if your build targets are under third_party/
 
 In the default case, with no options given, we use:
 - `highest` versionConflictPolicy

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -186,6 +186,7 @@ object Writer {
     if (badExports.nonEmpty) Left(badExports.toList.map(_.unversioned))
     else {
       val rootName = model.getOptions.getThirdPartyDirectory
+      val licenses = model.getOptions.getLicenses
       val pathInRoot = rootName.parts
 
       val langFn = language(g, model)
@@ -242,7 +243,8 @@ object Writer {
               exports = (exports + lab) ++ uvexports,
               jars = Set.empty,
               runtimeDeps = runtime_deps -- uvexports,
-              processorClasses = getProcessorClasses(u))
+              processorClasses = getProcessorClasses(u),
+              licenses = licenses)
           case _: Language.Scala =>
             Target(lang,
               kind = Target.Import,
@@ -250,7 +252,8 @@ object Writer {
               exports = exports ++ uvexports,
               jars = Set(lab),
               runtimeDeps = runtime_deps -- uvexports,
-              processorClasses = getProcessorClasses(u))
+              processorClasses = getProcessorClasses(u),
+              licenses = licenses)
         }
 
 

--- a/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
@@ -66,7 +66,8 @@ object ModelGenerators {
     heads <- Gen.option(Gen.listOf(Gen.identifier))
     cache <- Gen.option(Gen.oneOf(ResolverCache.Local, ResolverCache.BazelOutputBase))
     prefix <- Gen.option(Gen.identifier.map(NamePrefix(_)))
-  } yield Options(vcp, dir, langs, res, trans, heads, cache, prefix, None)
+    licenses <- Gen.option(Gen.someOf("unencumbered", "permissive", "restricted", "notice").map(_.toSet))
+  } yield Options(vcp, dir, langs, res, trans, heads, cache, prefix, licenses)
 
   val modelGen: Gen[Model] = for {
     o <- Gen.option(optionGen)

--- a/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
@@ -66,7 +66,7 @@ object ModelGenerators {
     heads <- Gen.option(Gen.listOf(Gen.identifier))
     cache <- Gen.option(Gen.oneOf(ResolverCache.Local, ResolverCache.BazelOutputBase))
     prefix <- Gen.option(Gen.identifier.map(NamePrefix(_)))
-  } yield Options(vcp, dir, langs, res, trans, heads, cache, prefix)
+  } yield Options(vcp, dir, langs, res, trans, heads, cache, prefix, None)
 
   val modelGen: Gen[Model] = for {
     o <- Gen.option(optionGen)

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
@@ -69,6 +69,7 @@ class ParseTest extends FunSuite {
               None,
               None,
               Some(ResolverCache.BazelOutputBase),
+              None,
               None)))))
   }
   test("parse empty subproject version") {
@@ -102,6 +103,7 @@ class ParseTest extends FunSuite {
               None,
               Some(DirectoryName("3rdparty/jvm")),
               Some(Set(Language.Scala(Version("2.11.7"), true), Language.Java)),
+              None,
               None,
               None,
               None,

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
@@ -45,6 +45,7 @@ class ParseTest extends FunSuite {
                 |  languages: ["scala:2.11.7", java]
                 |  thirdPartyDirectory: 3rdparty/jvm
                 |  resolverCache: bazel_output_base
+                |  licenses: ["unencumbered", "permissive"]
                 |""".stripMargin('|')
 
     assert(Decoders.decodeModel(Yaml, str) ==
@@ -70,7 +71,7 @@ class ParseTest extends FunSuite {
               None,
               Some(ResolverCache.BazelOutputBase),
               None,
-              None)))))
+              Some(Set("unencumbered", "permissive")))))))
   }
   test("parse empty subproject version") {
     val str = """dependencies:

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
@@ -20,7 +20,7 @@ class ParseTestCasesTest extends FunSuite {
     law(model)
 
     val model1 = Model(Dependencies.empty,Some(Replacements.empty),Some(Options(None,None,None,None,None,Some(List()),
-      Some(ResolverCache.Local),Some(NamePrefix("y")))))
+      Some(ResolverCache.Local),Some(NamePrefix("y")), None)))
     //println(model1.toDoc.render(70))
     law(model1)
   }


### PR DESCRIPTION
https://docs.bazel.build/versions/master/be/functions.html#licenses

If you put your BUILD files under third_party, bazel will throw an error
if there is no license tag.

Licenses are defined in the options section, as a Set[String]. It's a
global setting for now.