### PR TITLE
DO NOT MERGE: WIP/PoC for #69 -- add support for classifier

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
@@ -6,6 +6,7 @@ import io.circe.generic.auto
 
 object Decoders {
   implicit val versionDecoder: Decoder[Version] = stringWrapper(Version(_))
+  implicit val classifierDecoder: Decoder[Classifier] = stringWrapper(Classifier(_))
   implicit val processorClassDecoder: Decoder[ProcessorClass] = stringWrapper(ProcessorClass(_))
   implicit val subprojDecoder: Decoder[Subproject] = stringWrapper(Subproject(_))
   implicit val dirnameDecoder: Decoder[DirectoryName] = stringWrapper(DirectoryName(_))

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -169,6 +169,7 @@ object ArtifactOrProject {
 
 case class Subproject(asString: String)
 case class Version(asString: String)
+case class Classifier(asString: String)
 case class Sha1Value(toHex: String)
 case class MavenServer(id: String, contentType: String, url: String) {
   def toDoc: Doc =
@@ -270,14 +271,22 @@ object MavenArtifactId {
   }
 }
 
-case class MavenCoordinate(group: MavenGroup, artifact: MavenArtifactId, version: Version) {
-  def unversioned: UnversionedCoordinate = UnversionedCoordinate(group, artifact)
-  def asString: String = s"${group.asString}:${artifact.asString}:${version.asString}"
+case class MavenCoordinate(group: MavenGroup, artifact: MavenArtifactId, classifier: Classifier, version: Version) {
+  def unversioned: UnversionedCoordinate = UnversionedCoordinate(group, artifact, classifierOpt())
+  def asString: String = classifier match {
+    case Classifier("") => s"${group.asString}:${artifact.asString}:${version.asString}"
+    case Classifier(c) => s"${group.asString}:${artifact.asString}:jar:${c}:${version.asString}"
+  }
 
   def toDependencies(l: Language): Dependencies =
     Dependencies(Map(group ->
       Map(ArtifactOrProject(artifact.asString) ->
-        ProjectRecord(l, Some(version), None, None, None, None))))
+        ProjectRecord(l, classifierOpt(), Some(version), None, None, None, None))))
+
+  private def classifierOpt() = classifier match {
+    case Classifier("") => None
+    case Classifier(_) => Some(classifier)
+  }
 }
 
 object MavenCoordinate {
@@ -290,12 +299,16 @@ object MavenCoordinate {
 
   def parse(s: String): ValidatedNel[String, MavenCoordinate] =
     s.split(":") match {
+      case Array(g, a, _, c, v) => Validated.valid(MavenCoordinate(MavenGroup(g), MavenArtifactId(a), Classifier(c), Version(v)))
       case Array(g, a, v) => Validated.valid(MavenCoordinate(MavenGroup(g), MavenArtifactId(a), Version(v)))
       case other => Validated.invalidNel(s"expected exactly three :, got $s")
     }
 
   def apply(u: UnversionedCoordinate, v: Version): MavenCoordinate =
-    MavenCoordinate(u.group, u.artifact, v)
+    MavenCoordinate(u.group, u.artifact, u.classifier.getOrElse(Classifier("")), v)
+
+  def apply(g: MavenGroup, a: MavenArtifactId, v: Version) : MavenCoordinate =
+    MavenCoordinate(g, a, Classifier(""), v)  
 
   implicit def mvnCoordOrd: Ordering[MavenCoordinate] = Ordering.by { m: MavenCoordinate =>
     (m.group.asString, m.artifact.asString, m.version)
@@ -305,10 +318,10 @@ object MavenCoordinate {
 sealed abstract class Language {
   def asString: String
   def asOptionsString: String
-  def mavenCoord(g: MavenGroup, a: ArtifactOrProject, v: Version): MavenCoordinate
-  def mavenCoord(g: MavenGroup, a: ArtifactOrProject, sp: Subproject, v: Version): MavenCoordinate
-  def unversioned(g: MavenGroup, a: ArtifactOrProject): UnversionedCoordinate
-  def unversioned(g: MavenGroup, a: ArtifactOrProject, sp: Subproject): UnversionedCoordinate
+  def mavenCoord(g: MavenGroup, a: ArtifactOrProject, c: Option[Classifier], v: Version): MavenCoordinate
+  def mavenCoord(g: MavenGroup, a: ArtifactOrProject, sp: Subproject, c: Option[Classifier], v: Version): MavenCoordinate
+  def unversioned(g: MavenGroup, a: ArtifactOrProject, c: Option[Classifier]): UnversionedCoordinate
+  def unversioned(g: MavenGroup, a: ArtifactOrProject, sp: Subproject, c: Option[Classifier]): UnversionedCoordinate
 
   def unmangle(m: MavenCoordinate): MavenCoordinate
 }
@@ -317,17 +330,17 @@ object Language {
   case object Java extends Language {
     def asString = "java"
     def asOptionsString = asString
-    def mavenCoord(g: MavenGroup, a: ArtifactOrProject, v: Version): MavenCoordinate =
-      MavenCoordinate(g, MavenArtifactId(a), v)
+    def mavenCoord(g: MavenGroup, a: ArtifactOrProject, c: Option[Classifier], v: Version): MavenCoordinate =
+      MavenCoordinate(g, MavenArtifactId(a), c.getOrElse(Classifier("")), v)
 
-    def mavenCoord(g: MavenGroup, a: ArtifactOrProject, sp: Subproject, v: Version): MavenCoordinate =
-      MavenCoordinate(g, MavenArtifactId(a, sp), v)
+    def mavenCoord(g: MavenGroup, a: ArtifactOrProject, sp: Subproject, c: Option[Classifier], v: Version): MavenCoordinate =
+      MavenCoordinate(g, MavenArtifactId(a, sp), c.getOrElse(Classifier("")), v)
 
-    def unversioned(g: MavenGroup, a: ArtifactOrProject): UnversionedCoordinate =
-      UnversionedCoordinate(g, MavenArtifactId(a))
+    def unversioned(g: MavenGroup, a: ArtifactOrProject, c: Option[Classifier]): UnversionedCoordinate =
+      UnversionedCoordinate(g, MavenArtifactId(a), c)
 
-    def unversioned(g: MavenGroup, a: ArtifactOrProject, sp: Subproject): UnversionedCoordinate =
-      UnversionedCoordinate(g, MavenArtifactId(a, sp))
+    def unversioned(g: MavenGroup, a: ArtifactOrProject, sp: Subproject, c: Option[Classifier]): UnversionedCoordinate =
+      UnversionedCoordinate(g, MavenArtifactId(a, sp), c)
 
     def unmangle(m: MavenCoordinate) = m
   }
@@ -346,17 +359,17 @@ object Language {
       if (mangle) a.addSuffix(suffix)
       else a
 
-    def unversioned(g: MavenGroup, a: ArtifactOrProject): UnversionedCoordinate =
-      UnversionedCoordinate(g, add(MavenArtifactId(a)))
+    def unversioned(g: MavenGroup, a: ArtifactOrProject, c: Option[Classifier]): UnversionedCoordinate =
+      UnversionedCoordinate(g, add(MavenArtifactId(a)), c)
 
-    def unversioned(g: MavenGroup, a: ArtifactOrProject, sp: Subproject): UnversionedCoordinate =
-      UnversionedCoordinate(g, add(MavenArtifactId(a, sp)))
+    def unversioned(g: MavenGroup, a: ArtifactOrProject, sp: Subproject, c: Option[Classifier]): UnversionedCoordinate =
+      UnversionedCoordinate(g, add(MavenArtifactId(a, sp)), c)
 
-    def mavenCoord(g: MavenGroup, a: ArtifactOrProject, v: Version): MavenCoordinate =
-      MavenCoordinate(g, add(MavenArtifactId(a)), v)
+    def mavenCoord(g: MavenGroup, a: ArtifactOrProject, c: Option[Classifier], v: Version): MavenCoordinate =
+      MavenCoordinate(g, add(MavenArtifactId(a)), c.getOrElse(Classifier("")), v)
 
-    def mavenCoord(g: MavenGroup, a: ArtifactOrProject, sp: Subproject, v: Version): MavenCoordinate =
-      MavenCoordinate(g, add(MavenArtifactId(a, sp)), v)
+    def mavenCoord(g: MavenGroup, a: ArtifactOrProject, sp: Subproject, c: Option[Classifier], v: Version): MavenCoordinate =
+      MavenCoordinate(g, add(MavenArtifactId(a, sp)), c.getOrElse(Classifier("")), v)
 
     def removeSuffix(s: String): Option[String] =
       if (s.endsWith(suffix)) Some(s.dropRight(suffix.size))
@@ -366,10 +379,10 @@ object Language {
       uv.asString.endsWith(suffix)
 
     def unmangle(m: MavenCoordinate) = {
-      val MavenCoordinate(g, a, v) = m
+      val MavenCoordinate(g, a, c, v) = m
       removeSuffix(a.asString) match {
         case None => m
-        case Some(a) => MavenCoordinate(g, MavenArtifactId(a), v)
+        case Some(a) => MavenCoordinate(g, MavenArtifactId(a), c, v)
       }
     }
   }
@@ -381,8 +394,15 @@ object Language {
   implicit val ordering: Ordering[Language] = Ordering.by(_.asString)
 }
 
-case class UnversionedCoordinate(group: MavenGroup, artifact: MavenArtifactId) {
-  def asString: String = s"${group.asString}:${artifact.asString}"
+case class UnversionedCoordinate(group: MavenGroup, artifact: MavenArtifactId, classifier: Option[Classifier]) {
+
+  override lazy val hashCode: Int =
+    (group, artifact, classifier).hashCode
+
+  def asString: String = classifier match {
+    case None => s"${group.asString}:${artifact.asString}"
+    case Some(Classifier(c)) => s"${group.asString}:${artifact.asString}:jar:${c}"
+  }
   /**
    * This is a bazel-safe name to use as a remote repo name
    */
@@ -410,6 +430,7 @@ case class UnversionedCoordinate(group: MavenGroup, artifact: MavenArtifactId) {
 
 case class ProjectRecord(
   lang: Language,
+  classifier: Option[Classifier],
   version: Option[Version],
   modules: Option[Set[Subproject]],
   exports: Option[Set[(MavenGroup, ArtifactOrProject)]],
@@ -419,7 +440,7 @@ case class ProjectRecord(
 
   // Cache this
   override lazy val hashCode: Int =
-    (lang, version, modules, exports, exclude, processorClasses).hashCode
+    (lang, classifier, version, modules, exports, exclude, processorClasses).hashCode
 
   def flatten(ap: ArtifactOrProject): List[(ArtifactOrProject, ProjectRecord)] =
     getModules match {
@@ -463,16 +484,17 @@ case class ProjectRecord(
     ap: ArtifactOrProject): List[MavenCoordinate] =
     version.fold(List.empty[MavenCoordinate]) { v =>
       getModules match {
-        case Nil => List(lang.mavenCoord(g, ap, v))
-        case mods => mods.map { m => lang.mavenCoord(g, ap, m, v) }
+        case Nil => List(lang.mavenCoord(g, ap, classifier, v))
+        case mods => mods.map { m => lang.mavenCoord(g, ap, m, classifier, v) }
       }
     }
 
-  def allDependencies(g: MavenGroup, ap: ArtifactOrProject): List[UnversionedCoordinate] =
+  def allDependencies(g: MavenGroup, ap: ArtifactOrProject): List[UnversionedCoordinate] = {
     getModules match {
-      case Nil => List(lang.unversioned(g, ap))
-      case mods => mods.map { m => lang.unversioned(g, ap, m) }
+      case Nil => List(lang.unversioned(g, ap, classifier))
+      case mods => mods.map { m => lang.unversioned(g, ap, m, classifier) }
     }
+  }
 
   private def toList(s: Set[(MavenGroup, ArtifactOrProject)]): List[(MavenGroup, ArtifactOrProject)] =
     s.toList.sortBy { case (a, b) => (a.asString, b.asString) }
@@ -492,6 +514,7 @@ case class ProjectRecord(
       version.toList.map { v => ("version", quoteDoc(v.asString)) },
       modules.toList.map { ms =>
         ("modules", list(ms.map(_.asString).toList.sorted)(quoteDoc)) },
+      classifier.toList.map { c => ("classifier", quoteDoc(c.asString)) },
       exports.toList.map { ms =>
         ("exports", exportsDoc(ms)) },
       exclude.toList.map { ms =>
@@ -556,12 +579,14 @@ case class Dependencies(toMap: Map[MavenGroup, Map[ArtifactOrProject, ProjectRec
           }
         case parts =>
           // This can be split, but may not be:
-          val unsplit = ap.get(a).map(_.lang.unversioned(g, a)).toSet
+          val unsplit = ap.get(a).map(pr => {
+            pr.lang.unversioned(g, a, pr.classifier)
+          }).toSet
           val uvcs = unsplit.union(parts.flatMap { case (proj, subproj) =>
             ap.get(proj)
-              .map { pr => pr.getModules.filter(_ == subproj).map((_, pr.lang)) }
+              .map { pr => pr.getModules.filter(_ == subproj).map((_, pr.classifier, pr.lang)) }
               .getOrElse(Nil)
-              .map { case (m, lang) => lang.unversioned(g, proj, m) }
+              .map { case (m, classifier, lang) => lang.unversioned(g, proj, m, classifier) }
           }
           .toSet)
         if (uvcs.size == 1) Some(uvcs.head) else None
@@ -606,7 +631,7 @@ case class Dependencies(toMap: Map[MavenGroup, Map[ArtifactOrProject, ProjectRec
    * we need to potentially remove the scala version to check the
    * ArtifactOrProject key
    */
-  private def recordOf(m: UnversionedCoordinate): Option[ProjectRecord] =
+  def recordOf(m: UnversionedCoordinate): Option[ProjectRecord] =
     unversionedToProj.get(m)
 
   def languageOf(m: UnversionedCoordinate): Option[Language] =
@@ -618,7 +643,7 @@ case class Dependencies(toMap: Map[MavenGroup, Map[ArtifactOrProject, ProjectRec
       case Some(uvs) =>
         uvs.map { case (g, a) =>
           unversionedCoordinatesOf(g, a)
-            .getOrElse(UnversionedCoordinate(g, MavenArtifactId(a)))
+            .getOrElse(UnversionedCoordinate(g, MavenArtifactId(a), None))
         }.toSet
     }
 }
@@ -845,7 +870,7 @@ case class Replacements(toMap: Map[MavenGroup, Map[ArtifactOrProject, Replacemen
   val unversionedToReplacementRecord: Map[UnversionedCoordinate, ReplacementRecord] =
     toMap.flatMap { case (g, projs) =>
       projs.map { case (a, r) =>
-        r.lang.unversioned(g, a) -> r
+        r.lang.unversioned(g, a, None) -> r
       }
     }
 
@@ -853,7 +878,7 @@ case class Replacements(toMap: Map[MavenGroup, Map[ArtifactOrProject, Replacemen
     for {
       m <- toMap.get(g)
       r <- m.get(a)
-    } yield r.lang.unversioned(g, a)
+    } yield r.lang.unversioned(g, a, None)
 
   def get(uv: UnversionedCoordinate): Option[ReplacementRecord] =
     unversionedToReplacementRecord.get(uv)

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -44,7 +44,8 @@ object MakeDeps {
     val resolver = new Resolver(model.getOptions.getResolvers, resolverCachePath.toAbsolutePath)
     val graph = resolver.addAll(Graph.empty, deps.roots, model)
     // This is a defensive check that can be removed as we add more tests
-    deps.roots.foreach { m => require(graph.nodes(m), s"$m") }
+    deps.roots.foreach { m =>
+      require(graph.nodes(m), s"$m") }
 
     Normalizer(graph, deps.roots, model.getOptions.getVersionConflictPolicy) match {
       case None =>
@@ -56,6 +57,7 @@ object MakeDeps {
           .mkString("\n"))
         System.exit(1)
       case Some(normalized) =>
+
         /**
          * The graph is now normalized, lets get the shas
          */

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -44,8 +44,7 @@ object MakeDeps {
     val resolver = new Resolver(model.getOptions.getResolvers, resolverCachePath.toAbsolutePath)
     val graph = resolver.addAll(Graph.empty, deps.roots, model)
     // This is a defensive check that can be removed as we add more tests
-    deps.roots.foreach { m =>
-      require(graph.nodes(m), s"$m") }
+    deps.roots.foreach { m => require(graph.nodes(m), s"$m") }
 
     Normalizer(graph, deps.roots, model.getOptions.getVersionConflictPolicy) match {
       case None =>
@@ -57,7 +56,6 @@ object MakeDeps {
           .mkString("\n"))
         System.exit(1)
       case Some(normalized) =>
-
         /**
          * The graph is now normalized, lets get the shas
          */

--- a/src/scala/com/github/johnynek/bazel_deps/Resolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Resolver.scala
@@ -66,12 +66,17 @@ class Resolver(servers: List[MavenServer], resolverCachePath: Path) {
       val exclusion = new Exclusion(elem.group.asString, elem.artifact.asString, "", "jar")
       exclusions.add(exclusion)
     }
-    val classifier = m.classifier match {
-      case Classifier("") => null
-      case Classifier(c) => c
-    }
-    collectRequest.setRoot(new Dependency(new DefaultArtifact(
-      m.group.asString, m.artifact.asString, classifier, null, m.version.asString), "", false, exclusions))
+    collectRequest.setRoot(new Dependency(
+      new DefaultArtifact(
+        m.group.asString,
+        m.artifact.asString,
+        m.classifier.toNonEmptyString.orNull,
+        null /* packaging */,
+        m.version.asString
+      ),
+      null /* scope */,
+      false /* is dependency optional */,
+      exclusions))
     collectRequest.setRepositories(repositories)
     system.collectDependencies(session, collectRequest);
   }
@@ -82,12 +87,8 @@ class Resolver(servers: List[MavenServer], resolverCachePath: Path) {
      * and do the sha1.
      */
     def toArtifactRequest(m: MavenCoordinate, extension: String): ArtifactRequest = {
-      val classifier = m.classifier match {
-        case Classifier("") => null
-        case Classifier(c) => c
-      }
       val art = new DefaultArtifact(
-        m.group.asString, m.artifact.asString, classifier, extension, m.version.asString)
+        m.group.asString, m.artifact.asString, m.classifier.toNonEmptyString.orNull, extension, m.version.asString)
       val context = null
       new ArtifactRequest(art, repositories, context)
     }

--- a/src/scala/com/github/johnynek/bazel_deps/Resolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Resolver.scala
@@ -66,7 +66,12 @@ class Resolver(servers: List[MavenServer], resolverCachePath: Path) {
       val exclusion = new Exclusion(elem.group.asString, elem.artifact.asString, "", "jar")
       exclusions.add(exclusion)
     }
-    collectRequest.setRoot(new Dependency(new DefaultArtifact(m.asString), "", false, exclusions))
+    val classifier = m.classifier match {
+      case Classifier("") => null
+      case Classifier(c) => c
+    }
+    collectRequest.setRoot(new Dependency(new DefaultArtifact(
+      m.group.asString, m.artifact.asString, classifier, null, m.version.asString), "", false, exclusions))
     collectRequest.setRepositories(repositories)
     system.collectDependencies(session, collectRequest);
   }
@@ -77,7 +82,10 @@ class Resolver(servers: List[MavenServer], resolverCachePath: Path) {
      * and do the sha1.
      */
     def toArtifactRequest(m: MavenCoordinate, extension: String): ArtifactRequest = {
-      val classifier = null // We don't use this
+      val classifier = m.classifier match {
+        case Classifier("") => null
+        case Classifier(c) => c
+      }
       val art = new DefaultArtifact(
         m.group.asString, m.artifact.asString, classifier, extension, m.version.asString)
       val context = null
@@ -173,6 +181,7 @@ class Resolver(servers: List[MavenServer], resolverCachePath: Path) {
       val artifact = a.getArtifact
       MavenCoordinate(MavenGroup(artifact.getGroupId),
         MavenArtifactId(artifact.getArtifactId),
+        Classifier(artifact.getClassifier),
         Version(artifact.getVersion))
     }
 

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -66,7 +66,7 @@ object Writer {
     val lines = nodes.filterNot(replaced)
       .toList
       .sortBy(_.asString)
-      .map { case coord@MavenCoordinate(g, a, v) =>
+      .map { case coord@MavenCoordinate(g, a, c, v) =>
         val isRoot = model.dependencies.roots(coord)
         val (shaStr, serverStr) = shas.get(coord) match {
           case Some(Success(sha)) =>

--- a/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
@@ -41,7 +41,7 @@ object Tool {
     modules: Seq[String], //fixme
     dependencies: List[Dep] //fixme
   ) {
-    def toDep: Dep = Dep(groupId, artifactId, version, None)
+    def toDep: Dep = Dep(groupId, artifactId, version, None, None)
 
     def dir: String = directoryFor(path).getOrElse(".")
 
@@ -61,11 +61,12 @@ object Tool {
     groupId: String,
     artifactId: String,
     version: String,
-    scope: Option[String]) {
+    scope: Option[String],
+    classifier: Option[String]) {
 
     def unScalaVersion(s: Language.Scala): Option[Dep] =
       s.removeSuffix(artifactId)
-        .map(Dep(groupId, _, version, scope))
+        .map(Dep(groupId, _, version, scope, classifier))
 
     def hasScalaBinaryVersion: Boolean =
       artifactId.endsWith("${scala.binary.version}")
@@ -82,7 +83,7 @@ object Tool {
         })
       }
 
-      Dep(r(groupId), r(artifactId), r(version), scope)
+      Dep(r(groupId), r(artifactId), r(version), scope, classifier)
     }
   }
 
@@ -90,7 +91,8 @@ object Tool {
     Dep(singleText(e \ "groupId"),
       singleText(e \ "artifactId"),
       singleText(e \ "version"),
-      optionalText(e \ "scope"))
+      optionalText(e \ "scope"),
+      optionalText(e \ "classifier"))
 
   private def directoryFor(path: String): Option[String] = {
     val f = new File(path)
@@ -160,6 +162,7 @@ object Tool {
         (MavenGroup(d.groupId),
           ArtifactOrProject(d.artifactId),
           ProjectRecord(lang,
+            None,
             Some(Version(d.version)),
             None,
             None,
@@ -265,7 +268,7 @@ maven_dependencies(maven_load)
           else Language.Java
 
         (dep, Label.localTarget(List("3rdparty", "jvm"),
-          UnversionedCoordinate(MavenGroup(resolvedDep.groupId), MavenArtifactId(resolvedDep.artifactId)),
+          UnversionedCoordinate(MavenGroup(resolvedDep.groupId), MavenArtifactId(resolvedDep.artifactId), dep.classifier.map(Classifier(_))),
           lang))
       }
       .toMap

--- a/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
@@ -15,6 +15,7 @@ object ModelGenerators {
 
   def projectRecordGen(l1: Language, langs: List[Language]): Gen[ProjectRecord] = for {
     lang <- Gen.oneOf(l1 :: langs)
+    c <- Gen.option(Gen.identifier.map(i => Classifier(i.mkString)))
     v <- Gen.option(Gen.listOfN(3, Gen.choose('0', '9')).map { l => Version(l.mkString) })
     sub <- Gen.choose(0, 6)
     exp <- Gen.choose(0, 3)
@@ -24,7 +25,7 @@ object ModelGenerators {
     exports <- Gen.option(Gen.listOfN(exp, join(mavenGroupGen, artifactOrProjGen)).map(_.toSet))
     exclude <- Gen.option(Gen.listOfN(exc, join(mavenGroupGen, artifactOrProjGen)).map(_.toSet))
     processorClasses <- Gen.option(Gen.listOfN(pcs, processorClassGen).map(_.toSet))
-  } yield ProjectRecord(lang, v, m, exports, exclude, processorClasses)
+  } yield ProjectRecord(lang, c, v, m, exports, exclude, processorClasses)
 
   def depGen(o: Options): Gen[Dependencies] = {
     val (l1, ls) = o.getLanguages match {

--- a/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
@@ -33,7 +33,7 @@ class ModelTest extends FunSuite {
     val lang = Language.Scala.default
     val deps = Dependencies(Map(
       MavenGroup("com.twitter") -> Map(
-        ArtifactOrProject("finagle") -> ProjectRecord(lang, Some(Version("0.1")), Some(Set(Subproject(""), Subproject("core"))), None, None, None)
+        ArtifactOrProject("finagle") -> ProjectRecord(lang, None, Some(Version("0.1")), Some(Set(Subproject(""), Subproject("core"))), None, None, None)
       )
     ))
 
@@ -54,7 +54,7 @@ class ModelTest extends FunSuite {
   }
 
   test("coordinate naming") {
-    val uc = UnversionedCoordinate(MavenGroup("com.twitter"), MavenArtifactId("finagle-core"))
+    val uc = UnversionedCoordinate(MavenGroup("com.twitter"), MavenArtifactId("finagle-core"), None)
     assert(uc.asString == "com.twitter:finagle-core")
     assert(uc.toBazelRepoName(NamePrefix("")) == "com_twitter_finagle_core")
     assert(uc.toBindingName(NamePrefix("")) == "jar/com/twitter/finagle_core")

--- a/test/scala/com/github/johnynek/bazel_deps/NormalizerTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/NormalizerTest.scala
@@ -93,7 +93,7 @@ class NormalizerTest extends FunSuite  {
         case None => fail(s"couldn't normalize $g")
         case Some(g) =>
           // Each (group, artifact) pair appears only once in the nodes:
-          g.nodes.groupBy { case MavenCoordinate(g, a, _) => (g, a) }
+          g.nodes.groupBy { case MavenCoordinate(g, a, Classifier(""), _) => (g, a) }
             .foreach { case (_, vs) =>
               assert(vs.size == 1)
             }

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
@@ -25,6 +25,7 @@ class ParseTest extends FunSuite {
             Map(ArtifactOrProject("scalding") ->
               ProjectRecord(
                 Language.Scala.default,
+                None,
                 Some(Version("0.16.0")),
                 Some(Set("core", "args", "date").map(Subproject(_))),
                 None,
@@ -55,6 +56,7 @@ class ParseTest extends FunSuite {
             Map(ArtifactOrProject("scalding") ->
               ProjectRecord(
                 Language.Scala(Version("2.11.7"), true),
+                None,
                 Some(Version("0.16.0")),
                 Some(Set("core", "args", "date").map(Subproject(_))),
                 None,
@@ -93,6 +95,7 @@ class ParseTest extends FunSuite {
             Map(ArtifactOrProject("scalding") ->
               ProjectRecord(
                 Language.Scala(Version("2.11.7"), true),
+                None,
                 Some(Version("0.16.0")),
                 Some(Set("", "core", "args", "date").map(Subproject(_))),
                 None,
@@ -132,6 +135,7 @@ class ParseTest extends FunSuite {
             Map(ArtifactOrProject("auto-value") ->
               ProjectRecord(
                 Language.Java,
+                None,
                 Some(Version("1.5")),
                 None,
                 None,

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
@@ -13,7 +13,7 @@ class ParseTestCasesTest extends FunSuite {
       Map(
         MavenGroup("n2rr") ->
           Map(
-            ArtifactOrProject("zmup") -> ProjectRecord(Java,Some(Version("019")),Some(Set(Subproject("wcv"))),Some(Set((MavenGroup("j9szw4"),ArtifactOrProject("i")))),None,None)
+            ArtifactOrProject("zmup") -> ProjectRecord(Java,None,Some(Version("019")),Some(Set(Subproject("wcv"))),Some(Set((MavenGroup("j9szw4"),ArtifactOrProject("i")))),None,None)
           )
         )),Some(Replacements(Map())),None)
 


### PR DESCRIPTION
**DO NOT MERGE**.

Posting this in case it's helpful as a starting point for someone with much more scala-fu for me. I muddled through banging this code together, and it appears to work for our medium-(large?)-ish workspace. ~800 external deps. Something like 5 have classifiers. :) 

Worth noting:
* Not a scala developer. If I'm doing something super dumb, I will not be embarrassed if you tell me.
* This doesn't attempt at all to support the "compact" syntax that is supported for `modules`, and was suggested in #69. 
* Existing test pass, but I haven't implemented new ones.
* I haven't really tried to understand `maven/Tool.scala`, but I made it compile (I haven't tried to test it yet)
* This definitely conflicts with the fix for #119. Basically all the same lines, it looks like.
* There's a change to Normalizer.scala that I'm not sure is actually related to this PR. We get an apparently-infinite loop without it, but it might be (and probably is) related to some weird dependency structure in the maven artifacts we're using.

If someone else wants to build on this, be my guest. If someone has pointers as to how I can improve it, I'm on board for that too, but I don't know how much time I'll have myself.

Thanks!