### PR TITLE
Supporting classifiers and packaging in ArtifactOrProject

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,40 @@ Each group id can only appear once, so you should collocate dependencies by grou
 we are using does not fail on duplicate keys, it just takes the last one, so watch out. It would be good
 to fix that, but writing a new yaml parser is out of scope.
 
+#### <a name="packaging-classifiers">Packaging and Classifiers</a>
+
+Depending on artifacts with classifiers is straightforward: just add the packaging and classifier as part of the
+artifact id:
+
+```yaml
+dependencies:
+  net.sf.json-lib:
+    json-lib:jar:jdk15: # artifact:packaging:classifier
+      lang: java
+      version: "2.4"
+```
+
+**Note**: Currently, only `jar` packaging is supported for dependencies. More work is needed on the `bazel-deps` backend
+to ensure that non-jar dependencies are written as `data` attributes, instead of regular jar dependencies. 
+
+Excluding artifacts with packaging or classifiers is similar to including dependencies. Non-jar packaging _is_ supported
+for `exclude`.
+
+```yaml
+  com.amazonaws:
+    DynamoDBLocal:
+      lang: java
+      version: "1.11.86"
+      exclude:
+        - "com.almworks.sqlite4java:sqlite4java-win32-x86:dll"
+        - "com.almworks.sqlite4java:sqlite4java-win32-x64:dll"
+        - "com.almworks.sqlite4java:libsqlite4java-osx:dylib"
+        - "com.almworks.sqlite4java:libsqlite4java-linux-i386:so"
+        - "com.almworks.sqlite4java:libsqlite4java-linux-amd64:so"
+```
+
+#### <a name="annotation-processors">Annotation Processors (`processorClasses`)</a>
+
 A target may also optionally add `processorClasses` to a dependency. This is for [annotation processors](https://docs.oracle.com/javase/8/docs/api/javax/annotation/processing/Processor.html).
 `bazel-deps` will generate a `java_library` and a `java_plugin` for each annotation processor defined. For example, we can define Google's auto-value annotation processor via:
 ```

--- a/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
@@ -32,8 +32,10 @@ object Decoders {
   implicit val groupArtDecoder: Decoder[(MavenGroup, ArtifactOrProject)] =
     Decoder.decodeString.emap { s =>
       s.split(':') match {
+        case Array(g, a, p, c) => Right((MavenGroup(g), ArtifactOrProject(a, p, Some(c))))
+        case Array(g, a, p) => Right((MavenGroup(g), ArtifactOrProject(a, p, None)))
         case Array(g, a) => Right((MavenGroup(g), ArtifactOrProject(a)))
-        case _ => Left(s"did not find exactly one ':' in $s")
+        case _ => Left(s"$s did not match expected maven coord format <groupId>:<artifactId>[:<extension>[:<classifier>]]")
       }
     }
   implicit val resolverDecorder: Decoder[MavenServer] =

--- a/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
@@ -38,7 +38,7 @@ object Decoders {
         case _ => Left(s"$s did not match expected maven coord format <groupId>:<artifactId>[:<extension>[:<classifier>]]")
       }
     }
-  implicit val resolverDecorder: Decoder[MavenServer] =
+  implicit val resolverDecoder: Decoder[MavenServer] =
     Decoder.decodeMapLike[Map, String, String].emap { smap =>
       def expect(k: String): Either[String, String] =
         smap.get(k) match {

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -132,14 +132,13 @@ object Model {
 }
 
 case class MavenGroup(asString: String)
-case class ArtifactOrProject(
-  artifact: MavenArtifactId) {
-
-  def asString = artifact.asString
+case class ArtifactOrProject(artifact: MavenArtifactId) {
 
   private val artifactId = artifact.artifactId
   private val packaging = artifact.packaging
   private val classifier = artifact.classifier
+
+  def asString: String = artifact.asString
 
   val splitSubprojects: List[(ArtifactOrProject, Subproject)] =
     if (artifactId.contains('-')) {
@@ -332,7 +331,7 @@ case class MavenArtifactId(
   packaging: String,
   classifier: Option[String]) {
 
-  def asString = classifier match {
+  def asString: String = classifier match {
     case Some(c) => s"$artifactId:$packaging:$c"
     case None => if (packaging == MavenArtifactId.defaultPackaging) {
       artifactId
@@ -363,13 +362,13 @@ object MavenArtifactId {
     )
   }
 
-  def apply(str: String): MavenArtifactId = {
+  def apply(str: String): MavenArtifactId =
     str.split(":") match {
       case Array(a, p, c) => MavenArtifactId(a, p, Some(c))
       case Array(a, p) => MavenArtifactId(a, p, None)
       case Array(a) => MavenArtifactId(a, defaultPackaging, None)
+      case _ => sys.error(s"$str did not match expected format <artifactId>[:<packaging>[:<classifier>]]")
     }
-  }
 }
 
 case class MavenCoordinate(group: MavenGroup, artifact: MavenArtifactId, version: Version) {

--- a/src/scala/com/github/johnynek/bazel_deps/Label.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Label.scala
@@ -46,13 +46,16 @@ object Label {
     .toList))
 
     val artName = lang match {
-      case Language.Java => m.artifact.asString
-      case s@Language.Scala(_, true) =>
-        s.removeSuffix(m.artifact.asString) match {
-          case Some(n) => n
-          case None => sys.error(s"scala coordinate: ${m.asString} does not have correct suffix for $s")
+      case Language.Java => m.toTargetName
+      case s@Language.Scala(_, true) => {
+        val uvWithRemoved = s.removeSuffix(m)
+        if (m == uvWithRemoved) {
+          sys.error(s"scala coordinate: ${m.asString} does not have correct suffix for $s")
+        } else {
+          uvWithRemoved.toTargetName
         }
-      case Language.Scala(_, false) => m.artifact.asString
+      }
+      case Language.Scala(_, false) => m.toTargetName
     }
 
     val name = artName.map {

--- a/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
@@ -83,12 +83,8 @@ object Tool {
           props.getOrElse(k, "${" + k + "}")
         })
       }
-      def ropt(s: Option[String]): Option[String] = s match {
-        case Some(s) => Some(r(s))
-        case None => None
-      }
 
-      Dep(r(groupId), r(artifactId), r(version), scope, ropt(packaging), ropt(classifier))
+      Dep(r(groupId), r(artifactId), r(version), scope,packaging.map(r), classifier.map(r))
     }
   }
 

--- a/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
@@ -41,7 +41,7 @@ object Tool {
     modules: Seq[String], //fixme
     dependencies: List[Dep] //fixme
   ) {
-    def toDep: Dep = Dep(groupId, artifactId, version, None)
+    def toDep: Dep = Dep(groupId, artifactId, version, None, Some(packaging), None)
 
     def dir: String = directoryFor(path).getOrElse(".")
 
@@ -61,11 +61,13 @@ object Tool {
     groupId: String,
     artifactId: String,
     version: String,
-    scope: Option[String]) {
+    scope: Option[String],
+    packaging: Option[String], // corresponds to "<type>"
+    classifier: Option[String]) {
 
     def unScalaVersion(s: Language.Scala): Option[Dep] =
       s.removeSuffix(artifactId)
-        .map(Dep(groupId, _, version, scope))
+        .map(Dep(groupId, _, version, scope, packaging, classifier))
 
     def hasScalaBinaryVersion: Boolean =
       artifactId.endsWith("${scala.binary.version}")
@@ -81,8 +83,12 @@ object Tool {
           props.getOrElse(k, "${" + k + "}")
         })
       }
+      def ropt(s: Option[String]): Option[String] = s match {
+        case Some(s) => Some(r(s))
+        case None => None
+      }
 
-      Dep(r(groupId), r(artifactId), r(version), scope)
+      Dep(r(groupId), r(artifactId), r(version), scope, ropt(packaging), ropt(classifier))
     }
   }
 
@@ -90,7 +96,9 @@ object Tool {
     Dep(singleText(e \ "groupId"),
       singleText(e \ "artifactId"),
       singleText(e \ "version"),
-      optionalText(e \ "scope"))
+      optionalText(e \ "scope"),
+      optionalText(e \ "type"), // aka "packaging"
+      optionalText(e \ "classifier"))
 
   private def directoryFor(path: String): Option[String] = {
     val f = new File(path)
@@ -158,7 +166,8 @@ object Tool {
     val parts: List[(MavenGroup, ArtifactOrProject, ProjectRecord)] =
       externalDeps.iterator.map { case (d, lang) =>
         (MavenGroup(d.groupId),
-          ArtifactOrProject(d.artifactId),
+          ArtifactOrProject(MavenArtifactId(
+            d.artifactId, d.packaging.getOrElse(MavenArtifactId.defaultPackaging), d.classifier)),
           ProjectRecord(lang,
             Some(Version(d.version)),
             None,

--- a/test/scala/com/github/johnynek/bazel_deps/CoursierTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/CoursierTest.scala
@@ -93,4 +93,71 @@ dependencies:
       MavenCoordinate(
         MavenGroup("org.sonatype.sisu"), MavenArtifactId("sisu-guice", "jar", "no_aop"), Version("2.9.4"))))
   }
+
+  test("test non-jar packaging excludes example") {
+    val config = """
+options:
+  buildHeader: [ "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")" ]
+  languages: [ "java", "scala:2.11.8" ]
+  resolverType: "coursier"
+  resolvers:
+    - id: "mavencentral"
+      type: "default"
+      url: https://repo.maven.apache.org/maven2/
+  transitivity: runtime_deps
+  versionConflictPolicy: highest
+dependencies:
+  com.amazonaws:
+    aws-dynamodb-encryption-java:
+      lang: java
+      version: "1.11.0"
+      exclude:
+        - "com.almworks.sqlite4java:libsqlite4java-linux-amd64:so"
+"""
+
+    val model = Decoders.decodeModel(Yaml, config).right.get
+    val (graph, shas, normalized) = MakeDeps.runResolve(model, null).get
+
+    assert(graph.nodes.contains(
+      MavenCoordinate(
+        MavenGroup("com.amazonaws"), MavenArtifactId("aws-dynamodb-encryption-java"), Version("1.11.0"))))
+
+    // make sure no non-jar packaging shows up, until bazel-deps can handle setting those
+    // as data dependencies
+    val nonJarNodes = graph.nodes
+        .filter { mc => mc.artifact.packaging != "jar" }
+
+    assert(nonJarNodes.size == 0)
+  }
+
+  test("test jar packaging w/ classifier exclude example") {
+    val config =
+      """
+options:
+  buildHeader: [ "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")" ]
+  languages: [ "java", "scala:2.11.8" ]
+  resolverType: "coursier"
+  resolvers:
+    - id: "mavencentral"
+      type: "default"
+      url: https://repo.maven.apache.org/maven2/
+  transitivity: runtime_deps
+  versionConflictPolicy: highest
+dependencies:
+  org.sonatype.sisu:
+    sisu-inject-bean:
+      lang: java
+      version: "2.1.1"
+      exclude:
+        - "org.sonatype.sisu:sisu-guice:jar:no-aop"
+"""
+
+    val model = Decoders.decodeModel(Yaml, config).right.get
+    val (graph, shas, normalized) = MakeDeps.runResolve(model, null).get
+    // org.sonatype.sisu:sisu-guice:no_aop is a transitive dependency of org.sonatype.sisu:sisu-inject-bean
+    // we exclude it for this test
+    assert(!graph.nodes.contains(
+      MavenCoordinate(
+        MavenGroup("org.sonatype.sisu"), MavenArtifactId("sisu-guice", "jar", "no_aop"), Version("2.9.4"))))
+  }
 }

--- a/test/scala/com/github/johnynek/bazel_deps/CoursierTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/CoursierTest.scala
@@ -38,4 +38,59 @@ dependencies:
       assert(!uvc.asString.contains("bouncycastle"))
     }
   }
+
+  test("test classifier example") {
+    val config =
+      """
+options:
+  buildHeader: [ "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")" ]
+  languages: [ "java", "scala:2.11.8" ]
+  resolverType: "coursier"
+  resolvers:
+    - id: "mavencentral"
+      type: "default"
+      url: https://repo.maven.apache.org/maven2/
+  transitivity: runtime_deps
+  versionConflictPolicy: highest
+dependencies:
+  net.sf.json-lib:
+    json-lib:jar:jdk15:
+      lang: java
+      version: "2.4"
+"""
+
+    val model = Decoders.decodeModel(Yaml, config).right.get
+    val (graph, shas, normalized) = MakeDeps.runResolve(model, null).get
+    assert(graph.nodes.contains(
+      MavenCoordinate(
+        MavenGroup("net.sf.json-lib"), MavenArtifactId("json-lib", "jar", "jdk15"), Version("2.4"))))
+  }
+
+  test("test transitive classifier example") {
+    val config =
+      """
+options:
+  buildHeader: [ "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")" ]
+  languages: [ "java", "scala:2.11.8" ]
+  resolverType: "coursier"
+  resolvers:
+    - id: "mavencentral"
+      type: "default"
+      url: https://repo.maven.apache.org/maven2/
+  transitivity: runtime_deps
+  versionConflictPolicy: highest
+dependencies:
+  org.sonatype.sisu:
+    sisu-inject-bean:
+      lang: java
+      version: "2.1.1"
+"""
+
+    val model = Decoders.decodeModel(Yaml, config).right.get
+    val (graph, shas, normalized) = MakeDeps.runResolve(model, null).get
+    // org.sonatype.sisu:sisu-guice:no_aop is a transitive dependency of org.sonatype.sisu:sisu-inject-bean
+    assert(graph.nodes.contains(
+      MavenCoordinate(
+        MavenGroup("org.sonatype.sisu"), MavenArtifactId("sisu-guice", "jar", "no_aop"), Version("2.9.4"))))
+  }
 }

--- a/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
@@ -65,11 +65,11 @@ class ModelTest extends FunSuite {
     assert(uc.bindTarget(np) == "//external:jar/unique_com/twitter/finagle_core")
   }
 
-  test("packaging and classifier are extracted properly from MavenArtifactId") {
+  test("packaging and classifier are extracted properly parsed in MavenArtifactId") {
     def assertAll(id: MavenArtifactId, a: String, p: String, c: Option[String]) : Unit = {
-      assert(id.getArtifact == a)
-      assert(id.getPackaging == p)
-      assert(id.getClassifier == c)
+      assert(id.artifactId == a)
+      assert(id.packaging == p)
+      assert(id.classifier == c)
     }
 
     assertAll(MavenArtifactId("foo"), "foo", "jar", None)
@@ -77,18 +77,31 @@ class ModelTest extends FunSuite {
     assertAll(MavenArtifactId("foo:dll:tests"), "foo", "dll", Some("tests"))
   }
 
-  test("ArtifactOrProject asString") {
-    assert(ArtifactOrProject("foo", "jar", Some("some-classifier")).asString == "foo:jar:some-classifier")
-    assert(ArtifactOrProject("foo", "dll", Some("some-classifier")).asString == "foo:dll:some-classifier")
+  test("MavenArtifactId asString") {
+    assert(MavenArtifactId("foo", "jar", Some("some-classifier")).asString == "foo:jar:some-classifier")
+    assert(MavenArtifactId("foo", "dll", Some("some-classifier")).asString == "foo:dll:some-classifier")
 
     // rule: don't include packaging if packaging = jar and no classifier
-    assert(ArtifactOrProject("foo", "jar", None).asString == "foo")
-    assert(ArtifactOrProject("foo", "dll", None).asString == "foo:dll")
+    assert(MavenArtifactId("foo", "jar", None).asString == "foo")
+    assert(MavenArtifactId("foo", "dll", None).asString == "foo:dll")
 
     List("foo:jar:some-classifier", "foo", "foo:dll", "foo:dll:some-classifier").foreach { s => {
-      assert(ArtifactOrProject(s).asString == s)
+      assert(MavenArtifactId(s).asString == s)
     }}
 
-    assert(ArtifactOrProject("foo:jar").asString == "foo")
+    assert(MavenArtifactId("foo:jar").asString == "foo")
+  }
+
+  test("MavenArtifactId addSuffix") {
+    assert(MavenArtifactId("foo:dll:some-classifier").addSuffix("_1").asString == "foo_1:dll:some-classifier")
+    assert(MavenArtifactId("foo:dll").addSuffix("_1").asString == "foo_1:dll")
+    assert(MavenArtifactId("foo:jar:some-classifier").addSuffix("_1").asString == "foo_1:jar:some-classifier")
+
+    // special: remove default packaging
+    assert(MavenArtifactId("foo:jar").addSuffix("_1").asString == "foo_1")
+  }
+
+  test("MavenArtifactId packaging and classifier defaults") {
+
   }
 }

--- a/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
@@ -100,8 +100,4 @@ class ModelTest extends FunSuite {
     // special: remove default packaging
     assert(MavenArtifactId("foo:jar").addSuffix("_1").asString == "foo_1")
   }
-
-  test("MavenArtifactId packaging and classifier defaults") {
-
-  }
 }

--- a/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
@@ -64,4 +64,31 @@ class ModelTest extends FunSuite {
     assert(uc.toBindingName(np) == "jar/unique_com/twitter/finagle_core")
     assert(uc.bindTarget(np) == "//external:jar/unique_com/twitter/finagle_core")
   }
+
+  test("packaging and classifier are extracted properly from MavenArtifactId") {
+    def assertAll(id: MavenArtifactId, a: String, p: String, c: Option[String]) : Unit = {
+      assert(id.getArtifact == a)
+      assert(id.getPackaging == p)
+      assert(id.getClassifier == c)
+    }
+
+    assertAll(MavenArtifactId("foo"), "foo", "jar", None)
+    assertAll(MavenArtifactId("foo:dll"), "foo", "dll", None)
+    assertAll(MavenArtifactId("foo:dll:tests"), "foo", "dll", Some("tests"))
+  }
+
+  test("ArtifactOrProject asString") {
+    assert(ArtifactOrProject("foo", "jar", Some("some-classifier")).asString == "foo:jar:some-classifier")
+    assert(ArtifactOrProject("foo", "dll", Some("some-classifier")).asString == "foo:dll:some-classifier")
+
+    // rule: don't include packaging if packaging = jar and no classifier
+    assert(ArtifactOrProject("foo", "jar", None).asString == "foo")
+    assert(ArtifactOrProject("foo", "dll", None).asString == "foo:dll")
+
+    List("foo:jar:some-classifier", "foo", "foo:dll", "foo:dll:some-classifier").foreach { s => {
+      assert(ArtifactOrProject(s).asString == s)
+    }}
+
+    assert(ArtifactOrProject("foo:jar").asString == "foo")
+  }
 }

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
@@ -146,7 +146,7 @@ class ParseTest extends FunSuite {
   test("parse a file that includes packaging for an artifact") {
     val str = """dependencies:
                 |  com.google.auto.value:
-                |    "auto-value:dll":
+                |    auto-value:dll:
                 |      version: "1.5"
                 |      lang: java
                 |""".stripMargin('|')
@@ -170,7 +170,7 @@ class ParseTest extends FunSuite {
   test("parse a file that includes packaging for an artifact with subprojects") {
     val str = """dependencies:
                 |  com.google.auto.value:
-                |    "auto-value:dll":
+                |    auto-value:dll:
                 |      modules: ["", "extras"]
                 |      version: "1.5"
                 |      lang: java
@@ -195,7 +195,7 @@ class ParseTest extends FunSuite {
   test("parse a file that includes classifier") {
     val str = """dependencies:
                 |  com.google.auto.value:
-                |    "auto-value:dll:best-one":
+                |    auto-value:dll:best-one:
                 |      version: "1.5"
                 |      lang: java
                 |""".stripMargin('|')

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
@@ -216,6 +216,32 @@ class ParseTest extends FunSuite {
         None)))
   }
 
+  test("parse a file that _excludes_ something with a classifier") {
+    val str = """dependencies:
+                |  com.google.auto.value:
+                |    auto-value:
+                |      exclude:
+                |        - "foo:bar:so:fancy"
+                |      version: "1.5"
+                |      lang: java
+                |""".stripMargin('|')
+
+    assert(Decoders.decodeModel(Yaml, str) ==
+      Right(Model(
+        Dependencies(
+          MavenGroup("com.google.auto.value") ->
+            Map(ArtifactOrProject("auto-value") ->
+              ProjectRecord(
+                Language.Java,
+                Some(Version("1.5")),
+                None,
+                None,
+                Some(Set((MavenGroup("foo"), ArtifactOrProject(MavenArtifactId("bar:so:fancy"))))),
+                None))),
+        None,
+        None)))
+  }
+
   /*
    * TODO make this test pass
    * see: https://github.com/johnynek/bazel-deps/issues/15

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
@@ -142,6 +142,80 @@ class ParseTest extends FunSuite {
         None,
         None)))
   }
+
+  test("parse a file that includes packaging for an artifact") {
+    val str = """dependencies:
+                |  com.google.auto.value:
+                |    "auto-value:dll":
+                |      version: "1.5"
+                |      lang: java
+                |""".stripMargin('|')
+
+    assert(Decoders.decodeModel(Yaml, str) ==
+      Right(Model(
+        Dependencies(
+          MavenGroup("com.google.auto.value") ->
+            Map(ArtifactOrProject("auto-value:dll") ->
+              ProjectRecord(
+                Language.Java,
+                Some(Version("1.5")),
+                None,
+                None,
+                None,
+                None))),
+        None,
+        None)))
+  }
+
+  test("parse a file that includes packaging for an artifact with subprojects") {
+    val str = """dependencies:
+                |  com.google.auto.value:
+                |    "auto-value:dll":
+                |      modules: ["", "extras"]
+                |      version: "1.5"
+                |      lang: java
+                |""".stripMargin('|')
+
+    assert(Decoders.decodeModel(Yaml, str) ==
+      Right(Model(
+        Dependencies(
+          MavenGroup("com.google.auto.value") ->
+            Map(ArtifactOrProject("auto-value:dll") ->
+              ProjectRecord(
+                Language.Java,
+                Some(Version("1.5")),
+                Some(Set("", "extras").map(Subproject(_))),
+                None,
+                None,
+                None))),
+        None,
+        None)))
+  }
+
+  test("parse a file that includes classifier") {
+    val str = """dependencies:
+                |  com.google.auto.value:
+                |    "auto-value:dll:best-one":
+                |      version: "1.5"
+                |      lang: java
+                |""".stripMargin('|')
+
+    assert(Decoders.decodeModel(Yaml, str) ==
+      Right(Model(
+        Dependencies(
+          MavenGroup("com.google.auto.value") ->
+            Map(ArtifactOrProject("auto-value:dll:best-one") ->
+              ProjectRecord(
+                Language.Java,
+                Some(Version("1.5")),
+                None,
+                None,
+                None,
+                None))),
+        None,
+        None)))
+  }
+
   /*
    * TODO make this test pass
    * see: https://github.com/johnynek/bazel-deps/issues/15


### PR DESCRIPTION
Sorry for the churn on this. This is based on my comments in https://github.com/johnynek/bazel-deps/issues/69#issuecomment-372370151, and works on our codebase, and should work for multiple classifers. It supports the "front half" of specifying packaging and classifiers. (Classifiers should "just work", but there's no work done yet to distinguish between `jar` packaging and non-`jar` packaging in the BUILD files, so if you depend on a non-jar package, I believe the BUILD files will be broken.

* this works on our codebase. The only change is the addition of packaging+classifier
  in target names and bind
* needs some real tests
* needs consensus on the palatability of this .yaml syntax
* I probably broke scala somehow
* I snuck in support for `exclude` of particular packaging/classifiers

Definitely needs work:
* non-jar `packaging` is added to .bzl and BUILD files, but results in broken BUILD files
* needs test for the changes around excludes
* I haven't tested .yaml _generation_ yet, or the maven Tool.scala