### PR TITLE
Fix order of dependency comments in .bzl file

### DIFF
--- a/3rdparty/workspace.bzl
+++ b/3rdparty/workspace.bzl
@@ -22,8 +22,8 @@ def list_dependencies():
 # - io.circe:circe-jackson25_2.11:0.8.0 wanted version 2.5.5
     {"artifact": "com.fasterxml.jackson.core:jackson-core:2.5.5", "lang": "java", "sha1": "d0b416837b2b3907f298db2f785e9012b6881515", "repository": "https://repo.maven.apache.org/maven2/", "name": "com_fasterxml_jackson_core_jackson_core", "actual": "@com_fasterxml_jackson_core_jackson_core//jar", "bind": "jar/com/fasterxml/jackson/core/jackson_core"},
 # duplicates in com.fasterxml.jackson.core:jackson-databind promoted to 2.5.5
-# - io.circe:circe-jackson25_2.11:0.8.0 wanted version 2.5.5
 # - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.5.3 wanted version 2.5.3
+# - io.circe:circe-jackson25_2.11:0.8.0 wanted version 2.5.5
     {"artifact": "com.fasterxml.jackson.core:jackson-databind:2.5.5", "lang": "java", "sha1": "b08c3194166a230e60f56ac98bcd5cab5ee39d65", "repository": "https://repo.maven.apache.org/maven2/", "name": "com_fasterxml_jackson_core_jackson_databind", "actual": "@com_fasterxml_jackson_core_jackson_databind//jar", "bind": "jar/com/fasterxml/jackson/core/jackson_databind"},
     {"artifact": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.5.3", "lang": "java", "sha1": "8fc7e5a9911c3ab4b0dd7e74f12621681835e3fc", "repository": "https://repo.maven.apache.org/maven2/", "name": "com_fasterxml_jackson_dataformat_jackson_dataformat_yaml", "actual": "@com_fasterxml_jackson_dataformat_jackson_dataformat_yaml//jar", "bind": "jar/com/fasterxml/jackson/dataformat/jackson_dataformat_yaml"},
     {"artifact": "com.github.mpilquist:simulacrum_2.11:0.10.0", "lang": "scala", "sha1": "59bdbd0db647655e3fd9bdbaa2a362d6fe82516a", "repository": "https://repo.maven.apache.org/maven2/", "name": "com_github_mpilquist_simulacrum_2_11", "actual": "@com_github_mpilquist_simulacrum_2_11//jar:file", "bind": "jar/com/github/mpilquist/simulacrum_2_11"},
@@ -49,29 +49,29 @@ def list_dependencies():
     {"artifact": "org.codehaus.plexus:plexus-interpolation:1.16", "lang": "java", "sha1": "a868d4a603bd42c9dee67890c4e60e360a11838c", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_codehaus_plexus_plexus_interpolation", "actual": "@org_codehaus_plexus_plexus_interpolation//jar", "bind": "jar/org/codehaus/plexus/plexus_interpolation"},
     {"artifact": "org.codehaus.plexus:plexus-utils:3.0.10", "lang": "java", "sha1": "65e6460a49460d2ca038f8644ff9ae6d878733b8", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_codehaus_plexus_plexus_utils", "actual": "@org_codehaus_plexus_plexus_utils//jar", "bind": "jar/org/codehaus/plexus/plexus_utils"},
 # duplicates in org.eclipse.aether:aether-api fixed to 1.0.2.v20150114
-# - org.eclipse.aether:aether-connector-basic:1.0.2.v20150114 wanted version 1.0.2.v20150114
 # - org.apache.maven:maven-aether-provider:3.1.0 wanted version 0.9.0.M2
+# - org.eclipse.aether:aether-connector-basic:1.0.2.v20150114 wanted version 1.0.2.v20150114
+# - org.eclipse.aether:aether-impl:1.0.2.v20150114 wanted version 1.0.2.v20150114
 # - org.eclipse.aether:aether-transport-file:1.0.2.v20150114 wanted version 1.0.2.v20150114
 # - org.eclipse.aether:aether-transport-http:1.0.2.v20150114 wanted version 1.0.2.v20150114
-# - org.eclipse.aether:aether-impl:1.0.2.v20150114 wanted version 1.0.2.v20150114
     {"artifact": "org.eclipse.aether:aether-api:1.0.2.v20150114", "lang": "java", "sha1": "839f93a5213fb3e233b09bfd6d6b95669f7043c0", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_aether_aether_api", "actual": "@org_eclipse_aether_aether_api//jar", "bind": "jar/org/eclipse/aether/aether_api"},
     {"artifact": "org.eclipse.aether:aether-connector-basic:1.0.2.v20150114", "lang": "java", "sha1": "d55c03b16efc16f25e1fd9fe0f37878fddbeed68", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_aether_aether_connector_basic", "actual": "@org_eclipse_aether_aether_connector_basic//jar", "bind": "jar/org/eclipse/aether/aether_connector_basic"},
     {"artifact": "org.eclipse.aether:aether-impl:1.0.2.v20150114", "lang": "java", "sha1": "f147539e6e60dfbda9ef7f6d750066170f61b7a1", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_aether_aether_impl", "actual": "@org_eclipse_aether_aether_impl//jar", "bind": "jar/org/eclipse/aether/aether_impl"},
 # duplicates in org.eclipse.aether:aether-spi promoted to 1.0.2.v20150114
-# - org.eclipse.aether:aether-connector-basic:1.0.2.v20150114 wanted version 1.0.2.v20150114
 # - org.apache.maven:maven-aether-provider:3.1.0 wanted version 0.9.0.M2
+# - org.eclipse.aether:aether-connector-basic:1.0.2.v20150114 wanted version 1.0.2.v20150114
+# - org.eclipse.aether:aether-impl:1.0.2.v20150114 wanted version 1.0.2.v20150114
 # - org.eclipse.aether:aether-transport-file:1.0.2.v20150114 wanted version 1.0.2.v20150114
 # - org.eclipse.aether:aether-transport-http:1.0.2.v20150114 wanted version 1.0.2.v20150114
-# - org.eclipse.aether:aether-impl:1.0.2.v20150114 wanted version 1.0.2.v20150114
     {"artifact": "org.eclipse.aether:aether-spi:1.0.2.v20150114", "lang": "java", "sha1": "8428dfa330107984f3e3ac05cc3ebd50b2676866", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_aether_aether_spi", "actual": "@org_eclipse_aether_aether_spi//jar", "bind": "jar/org/eclipse/aether/aether_spi"},
     {"artifact": "org.eclipse.aether:aether-transport-file:1.0.2.v20150114", "lang": "java", "sha1": "79ffcce2aa9c525ad5a1d0fc3f9669133c3f9572", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_aether_aether_transport_file", "actual": "@org_eclipse_aether_aether_transport_file//jar", "bind": "jar/org/eclipse/aether/aether_transport_file"},
     {"artifact": "org.eclipse.aether:aether-transport-http:1.0.2.v20150114", "lang": "java", "sha1": "262b7fb2e9872f470c059bc4053a3f2f7449932d", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_aether_aether_transport_http", "actual": "@org_eclipse_aether_aether_transport_http//jar", "bind": "jar/org/eclipse/aether/aether_transport_http"},
 # duplicates in org.eclipse.aether:aether-util promoted to 1.0.2.v20150114
-# - org.eclipse.aether:aether-connector-basic:1.0.2.v20150114 wanted version 1.0.2.v20150114
 # - org.apache.maven:maven-aether-provider:3.1.0 wanted version 0.9.0.M2
+# - org.eclipse.aether:aether-connector-basic:1.0.2.v20150114 wanted version 1.0.2.v20150114
+# - org.eclipse.aether:aether-impl:1.0.2.v20150114 wanted version 1.0.2.v20150114
 # - org.eclipse.aether:aether-transport-file:1.0.2.v20150114 wanted version 1.0.2.v20150114
 # - org.eclipse.aether:aether-transport-http:1.0.2.v20150114 wanted version 1.0.2.v20150114
-# - org.eclipse.aether:aether-impl:1.0.2.v20150114 wanted version 1.0.2.v20150114
     {"artifact": "org.eclipse.aether:aether-util:1.0.2.v20150114", "lang": "java", "sha1": "d2d3c74a5210544b5cdce89a2c1d1c62835692d1", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_aether_aether_util", "actual": "@org_eclipse_aether_aether_util//jar", "bind": "jar/org/eclipse/aether/aether_util"},
     {"artifact": "org.eclipse.sisu:org.eclipse.sisu.inject:0.0.0.M2a", "lang": "java", "sha1": "17941e32c751179a9628b25f54ce5641edafb9be", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_sisu_org_eclipse_sisu_inject", "actual": "@org_eclipse_sisu_org_eclipse_sisu_inject//jar", "bind": "jar/org/eclipse/sisu/org_eclipse_sisu_inject"},
     {"artifact": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.0.0.M2a", "lang": "java", "sha1": "07510dc8dfe27a0b57c17601bc760b7b0c8f95fa", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_sisu_org_eclipse_sisu_plexus", "actual": "@org_eclipse_sisu_org_eclipse_sisu_plexus//jar", "bind": "jar/org/eclipse/sisu/org_eclipse_sisu_plexus"},

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -88,7 +88,7 @@ object Writer {
             s"""# duplicates in ${coord.unversioned.asString} $status\n""" +
               vs.filterNot(e => replaced(e.source)).map { e =>
                 s"""# - ${e.source.asString} wanted version ${e.destination.version.asString}\n"""
-              }.mkString("")
+              }.toSeq.sorted.mkString("")
           case None =>
             ""
         }


### PR DESCRIPTION
This fixes the order of the dependency comments from #105 to minimize unnecessary changes in `git diff`.

I picked string sort order arbitrarily to enforce _some_ ordering, but I don't actually feel strongly about what the ordering is. Happy to change it to whatever.