### PR TITLE
Trim empty lines.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ script:
   - bazel test --test_output errors //...
   - bazel build src/scala/com/github/johnynek/bazel_deps/parseproject_deploy.jar
   - ./gen_maven_deps.sh generate -r `pwd` -s 3rdparty/workspace.bzl -d dependencies.yaml
-  - bazel run //:parse -- format-deps --overwrite --deps $TRAVIS_BUILD_DIR/dependencies.yaml
+  - bazel run //:parse -- format-deps --overwrite --deps $PWD/dependencies.yaml
   - git diff --exit-code

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,5 @@ script:
   - bazel test --test_output errors //...
   - bazel build src/scala/com/github/johnynek/bazel_deps/parseproject_deploy.jar
   - ./gen_maven_deps.sh generate -r `pwd` -s 3rdparty/workspace.bzl -d dependencies.yaml
+  - bazel run //:parse -- format-deps --overwrite --deps $TRAVIS_BUILD_DIR/dependencies.yaml
   - git diff --exit-code

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,7 @@ maven_dependencies()
 new_git_repository(
     name = "org_typelevel_paiges",
     remote = "git://github.com/typelevel/paiges",
-    commit = "0cdb92ac7f40cb251a76077cb0ac92b68a620c57",
+    commit = "8df2440d3bb4260b0772d6971e14c9d9322b077d",
     # inconsistency in how we refer to build paths in new_native/new git
     build_file = "3rdparty/manual/BUILD.paiges",
     # use target: "@org_typelevel_paiges//:paiges"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,8 +1,7 @@
 options:
+  buildHeader: [ "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")" ]
   languages: [ "java", "scala:2.11.8" ]
-  buildHeader:
-    - load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")
-  resolvers: 
+  resolvers:
     - id: "mavencentral"
       type: "default"
       url: https://repo.maven.apache.org/maven2/
@@ -13,48 +12,48 @@ dependencies:
   com.chuusai:
     shapeless:
       lang: scala
-  
+
   com.fasterxml.jackson.dataformat:
     jackson-dataformat-yaml:
       lang: java
       version: "2.5.3"
-  
+
   com.github.mpilquist:
     simulacrum:
-      exports: 
+      exports:
         - "org.typelevel:macro-compat"
       lang: scala
-  
+
   io.circe:
     circe:
       lang: scala
       modules: [ "core", "jackson25", "parser" ]
       version: "0.8.0"
     circe-generic:
-      exports: 
+      exports:
         - "com.chuusai:shapeless"
         - "org.typelevel:cats-core"
         - "org.typelevel:cats-kernel"
         - "org.typelevel:macro-compat"
       lang: scala
       version: "0.8.0"
-  
+
   org.apache.maven:
     maven-aether-provider:
       lang: java
       version: "3.1.0"
-  
+
   org.eclipse.aether:
     aether:
       lang: java
       modules: [ "api", "connector-basic", "impl", "transport-file", "transport-http" ]
       version: "1.0.2.v20150114"
-  
+
   org.scala-lang.modules:
     scala-xml:
       lang: scala
       version: "1.0.6"
-  
+
   org.scalacheck:
     scalacheck:
       lang: scala
@@ -64,10 +63,10 @@ dependencies:
     scalactic:
       lang: scala
       version: "3.0.1"
-  
+
   org.scalatest:
     scalatest:
-      exports: 
+      exports:
         - "org.scalactic:scalactic"
       lang: scala
       version: "3.0.1"
@@ -76,7 +75,7 @@ dependencies:
     slf4j-simple:
       lang: java
       version: "1.7.25"
-  
+
   org.spire-math:
     kind-projector:
       lang: scala
@@ -88,7 +87,7 @@ dependencies:
       modules: [ "free", "kernel", "macros" ]
       version: "0.9.0"
     cats-core:
-      exports: 
+      exports:
         - "org.typelevel:cats-kernel"
       lang: scala
       version: "0.9.0"
@@ -106,7 +105,7 @@ replacements:
     scala-reflect:
       lang: scala/unmangled
       target: "@scala//:scala-reflect"
-  
+
   org.scala-lang.modules:
     scala-parser-combinators:
       lang: scala

--- a/src/scala/com/github/johnynek/bazel_deps/FormatDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/FormatDeps.scala
@@ -31,7 +31,7 @@ object FormatDeps {
       case Right(m) => m
     }
 
-    val stream = model.toDoc.renderStream(100)
+    val stream = model.toDoc.renderStreamTrim(100)
     if (overwrite) {
       val pw = new PrintWriter(path)
       stream.foreach(pw.print(_))


### PR DESCRIPTION
When running `format-deps` the formatted `dependencies.yaml` will have lines containing only whitespace. This makes those lines empty.

The update to `paiges` uses the [v0.2.1 tag](https://github.com/typelevel/paiges/tree/v0.2.1) to include the fix to trimming in typelevel/paiges#80.