### PR TITLE
Use SLF4J logging in MakeDeps and related code.

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/src/scala/com/github/johnynek/bazel_deps/BUILD
@@ -56,7 +56,8 @@ scala_library(name = "io",
               srcs = ["IO.scala"],
               deps = [
                   "//3rdparty/jvm/org/typelevel:cats_core",
-                  "//3rdparty/jvm/org/typelevel:cats_free"
+                  "//3rdparty/jvm/org/typelevel:cats_free",
+                  "//3rdparty/jvm/org/slf4j:slf4j_api",
               ],
               exports = [
                   "//3rdparty/jvm/org/typelevel:cats_free"
@@ -78,6 +79,7 @@ scala_library(name = "writer",
                       ":io",
                       "//3rdparty/jvm/org/typelevel:cats_core",
                       "//3rdparty/jvm/org/typelevel:cats_free",
+                      "//3rdparty/jvm/org/slf4j:slf4j_api",
                       "@org_typelevel_paiges//:paiges",
                       ],
               visibility = ["//visibility:public"])
@@ -90,6 +92,7 @@ scala_library(name = "makedeps",
                  "//3rdparty/jvm/org/eclipse/aether:aether_api",
                  "//3rdparty/jvm/org/typelevel:cats_core",
                  "//3rdparty/jvm/org/typelevel:cats_free",
+                 "//3rdparty/jvm/org/slf4j:slf4j_api",
                  ":circeyaml",
                  ":commands",
                  ":decoders",
@@ -108,8 +111,6 @@ scala_binary(name = "parseproject",
              deps = [
                  ":makedeps",
                  ":commands",
-                 ],
-             runtime_deps = [
                  "//3rdparty/jvm/org/slf4j:slf4j_simple",
              ],
              main_class = "com.github.johnynek.bazel_deps.ParseProject",

--- a/src/scala/com/github/johnynek/bazel_deps/Commands.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Commands.scala
@@ -40,9 +40,17 @@ object Verbosity {
         case None => Validated.invalidNel(errorMessage(s))
       }
   }
+
+  val opt = Opts.option[Verbosity](
+    "verbosity",
+    short = "v",
+    help = Verbosity.helpMessage
+  ).orElse(Opts(Verbosity.Warn))
 }
 
-sealed abstract class Command
+sealed abstract class Command {
+  def verbosity: Verbosity
+}
 
 object Command {
   case class Generate(
@@ -87,29 +95,23 @@ object Command {
       "check-only",
       help = "if set, the generated files are checked against the existing files but are not written; exits 0 if the files match").orFalse
 
-    val verbosity = Opts.option[Verbosity](
-      "verbosity",
-      short = "v",
-      help = Verbosity.helpMessage
-    ).orElse(Opts(Verbosity.Warn))
-
-    (repoRoot |@| depsFile |@| shaFile |@| buildifier |@| checkOnly |@| verbosity).map(Generate(_, _, _, _, _, _))
+    (repoRoot |@| depsFile |@| shaFile |@| buildifier |@| checkOnly |@| Verbosity.opt).map(Generate(_, _, _, _, _, _))
   }
 
-  case class FormatDeps(deps: Path, overwrite: Boolean) extends Command
+  case class FormatDeps(deps: Path, overwrite: Boolean, verbosity: Verbosity) extends Command
   val format = DCommand("format-deps", "format the dependencies yaml file") {
     val depsFile = Opts.option[Path]("deps", short = "d", help = "the ABSOLUTE path to your dependencies yaml file")
     val overwrite = Opts.flag("overwrite", short = "o", help = "if set, we overwrite the file after we read it").orFalse
 
-    (depsFile |@| overwrite).map(FormatDeps(_, _))
+    (depsFile |@| overwrite |@| Verbosity.opt).map(FormatDeps(_, _, _))
   }
 
-  case class MergeDeps(deps: NonEmptyList[Path], output: Option[Path]) extends Command
+  case class MergeDeps(deps: NonEmptyList[Path], output: Option[Path], verbosity: Verbosity) extends Command
   val mergeDeps = DCommand("merge-deps", "merge a series of dependencies yaml file") {
     val deps = Opts.options[Path]("deps", short = "d", help = "list of ABSOLUTE paths of files to merge")
     val out = Opts.option[Path]("output", short = "o", help = "merged output file").orNone
 
-    (deps |@| out).map(MergeDeps(_, _))
+    (deps |@| out |@| Verbosity.opt).map(MergeDeps(_, _, _))
   }
 
   implicit val langArg: Argument[Language] = new Argument[Language] {
@@ -126,13 +128,13 @@ object Command {
     def read(s: String) = MavenCoordinate.parse(s)
   }
 
-  case class AddDep(deps: Path, lang: Language, coords: NonEmptyList[MavenCoordinate]) extends Command
+  case class AddDep(deps: Path, lang: Language, coords: NonEmptyList[MavenCoordinate], verbosity: Verbosity) extends Command
   val addDep = DCommand("add-dep", "add dependencies (of a single language) to the yaml file") {
     val p = Opts.option[Path]("deps", short = "d", help = "the YAML dependency file to add to")
     val lang = Opts.option[Language]("lang", short = "l", help = "the language of the given maven coordinate")
     val mcs = Opts.arguments[MavenCoordinate]("mvn-coord")
 
-    (p |@| lang |@| mcs).map(AddDep(_, _, _))
+    (p |@| lang |@| mcs |@| Verbosity.opt).map(AddDep(_, _, _, _))
   }
 
   val command: DCommand[Command] =

--- a/src/scala/com/github/johnynek/bazel_deps/IO.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/IO.scala
@@ -8,6 +8,7 @@ import java.io.{File, FileOutputStream, IOException}
 import java.nio.file.{Files, SimpleFileVisitor, FileVisitResult, Path => JPath}
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.Arrays
+import org.slf4j.LoggerFactory
 import scala.util.{ Failure, Success, Try }
 
 import cats.implicits._
@@ -19,6 +20,8 @@ import cats.implicits._
 object IO {
   val charset = "UTF-8"
   val pathSeparator = File.separator
+
+  private[this] val logger = LoggerFactory.getLogger("IO")
 
   case class Path(parts: List[String]) {
     def child(p: String): Path = Path(parts ++ List(p))
@@ -88,7 +91,7 @@ object IO {
   def run[A](io: Result[A], root: File)(resume: A => Unit): Unit =
     io.foldMap(IO.fileSystemExec(root)) match {
       case Failure(err) =>
-        System.err.println(err)
+        logger.error("Failure during IO:", err)
         System.exit(-1)
       case Success(result) =>
         resume(result)

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -14,8 +14,6 @@ object MakeDeps {
 
   def apply(g: Command.Generate): Unit = {
 
-    logger.info("hello world!")
-
     val content: String = Model.readFile(g.absDepsFile) match {
       case Success(str) => str
       case Failure(err) =>

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -1,20 +1,25 @@
 package com.github.johnynek.bazel_deps
 
+import cats.instances.try_._
 import java.io.File
 import java.nio.file.Paths
 import io.circe.jawn.JawnParser
+import org.slf4j.LoggerFactory
 import scala.sys.process.{ BasicIO, Process, ProcessIO }
 import scala.util.{ Failure, Success, Try }
-import cats.instances.try_._
 
 object MakeDeps {
 
+  private[this] val logger = LoggerFactory.getLogger("MakeDeps")
+
   def apply(g: Command.Generate): Unit = {
+
+    logger.info("hello world!")
 
     val content: String = Model.readFile(g.absDepsFile) match {
       case Success(str) => str
       case Failure(err) =>
-        System.err.println(s"[ERROR]: Failed to read ${g.depsFile}.\n$err")
+        logger.error(s"Failed to read ${g.depsFile}", err)
         System.exit(1)
         sys.error("unreachable")
     }
@@ -23,7 +28,7 @@ object MakeDeps {
     val model = Decoders.decodeModel(parser, content) match {
       case Right(m) => m
       case Left(err) =>
-        System.err.println(s"[ERROR]: Failed to parse ${g.depsFile}.\n$err")
+        logger.error(s"Failed to parse ${g.depsFile}.", err)
         System.exit(1)
         sys.error("unreachable")
     }
@@ -35,7 +40,7 @@ object MakeDeps {
         Try(Process(List("bazel", "info", "output_base"), projectRoot) !!) match {
           case Success(path) => Paths.get(path.trim, "bazel-deps/local-repo")
           case Failure(err) =>
-            System.err.println(s"[ERROR]: Could not find resolver cache path -- `bazel info output_base` failed.\n$err")
+            logger.error(s"Could not find resolver cache path -- `bazel info output_base` failed.", err)
             System.exit(1)
             sys.error("unreachable")
         }
@@ -48,12 +53,12 @@ object MakeDeps {
 
     Normalizer(graph, deps.roots, model.getOptions.getVersionConflictPolicy) match {
       case None =>
-        println("[ERROR] could not normalize versions:")
-        println(graph.nodes.groupBy(_.unversioned)
+        val output = graph.nodes.groupBy(_.unversioned)
           .mapValues { _.map(_.version).toList.sorted }
           .filter { case (_, s) => s.lengthCompare(1) > 0 }
           .map { case (u, vs) => s"""${u.asString}: ${vs.mkString(", ")}\n""" }
-          .mkString("\n"))
+          .mkString("\n")
+        logger.error(s"could not normalize versions:\n$output")
         System.exit(1)
       case Some(normalized) =>
         /**
@@ -77,8 +82,8 @@ object MakeDeps {
           }.toList match {
             case Nil => ()
             case missing =>
-              System.err.println(
-                s"Missing unversioned deps in the normalized graph: ${missing.map(_.asString).mkString(" ")}")
+              val output = missing.map(_.asString).mkString(" ")
+              logger.error(s"Missing unversioned deps in the normalized graph: $output")
               System.exit(-1)
           }
 
@@ -92,7 +97,7 @@ object MakeDeps {
         val targets = Writer.targets(normalized, model) match {
           case Right(t) => t
           case Left(err) =>
-            System.err.println(s"""Could not find explicit exports named by: ${err.mkString(", ")}""")
+            logger.error(s"""Could not find explicit exports named by: ${err.mkString(", ")}""")
             System.exit(-1)
             sys.error("exited already")
         }
@@ -114,7 +119,7 @@ object MakeDeps {
             val exit = Process(List(buildifierPath, "-path", p.asString, "-"), projectRoot).run(processIO).exitValue
             // Blocks until the process exits.
             if (exit != 0) {
-              System.err.println(s"buildifier $buildifierPath failed (code $exit) for ${p.asString}:\n$error")
+              logger.error(s"buildifier $buildifierPath failed (code $exit) for ${p.asString}:\n$error")
               System.exit(-1)
               sys.error("unreachable")
             }
@@ -143,14 +148,14 @@ object MakeDeps {
     // Here we actually run the whole thing
     io.foldMap(IO.fileSystemExec(projectRoot)) match {
       case Failure(err) =>
-        System.err.println(err)
+        logger.error("Failure during IO:", err)
         System.exit(-1)
       case Success(comparisons) =>
         val mismatchedFiles = comparisons.filter(!_.ok)
         if (mismatchedFiles.isEmpty) {
           println(s"all ${comparisons.size} generated files are up-to-date")
         } else {
-          System.err.println(s"some generated files are not up-to-date:\n${mismatchedFiles.map(_.path.asString).sorted.mkString("\n")}")
+          logger.error(s"some generated files are not up-to-date:\n${mismatchedFiles.map(_.path.asString).sorted.mkString("\n")}")
           System.exit(2)
         }
     }
@@ -170,7 +175,7 @@ object MakeDeps {
     // Here we actually run the whole thing
     io.foldMap(IO.fileSystemExec(projectRoot)) match {
       case Failure(err) =>
-        System.err.println(err)
+        logger.error("Failure during IO:", err)
         System.exit(-1)
       case Success(builds) =>
         println(s"wrote ${targets.size} targets in $builds BUILD files")

--- a/src/scala/com/github/johnynek/bazel_deps/ParseProject.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/ParseProject.scala
@@ -8,6 +8,8 @@ object ParseProject {
         if (help.errors.isEmpty) System.exit(0)
         else System.exit(1)
       case Right(gen: Command.Generate) =>
+        val level = gen.verbosity.repr.toUpperCase
+        System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, level)
         MakeDeps(gen)
       case Right(gen: Command.FormatDeps) =>
         FormatDeps(gen.deps.toFile, gen.overwrite)

--- a/src/scala/com/github/johnynek/bazel_deps/ParseProject.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/ParseProject.scala
@@ -1,5 +1,7 @@
 package com.github.johnynek.bazel_deps
 
+import org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY
+
 object ParseProject {
   def main(args: Array[String]): Unit = {
     Command.command.parse(args) match {
@@ -7,16 +9,19 @@ object ParseProject {
         System.err.println(help)
         if (help.errors.isEmpty) System.exit(0)
         else System.exit(1)
-      case Right(gen: Command.Generate) =>
-        val level = gen.verbosity.repr.toUpperCase
-        System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, level)
-        MakeDeps(gen)
-      case Right(gen: Command.FormatDeps) =>
-        FormatDeps(gen.deps.toFile, gen.overwrite)
-      case Right(Command.MergeDeps(ms, out)) =>
-        MergeDeps(ms, out)
-      case Right(Command.AddDep(yaml, lang, coords)) =>
-        MergeDeps.addDep(yaml, lang, coords)
+      case Right(command) =>
+        val level = command.verbosity.repr.toUpperCase
+        System.setProperty(DEFAULT_LOG_LEVEL_KEY, level)
+        command match {
+          case gen: Command.Generate =>
+            MakeDeps(gen)
+          case gen: Command.FormatDeps =>
+            FormatDeps(gen.deps.toFile, gen.overwrite)
+          case Command.MergeDeps(ms, out, _) =>
+            MergeDeps(ms, out)
+          case Command.AddDep(yaml, lang, coords, _) =>
+            MergeDeps.addDep(yaml, lang, coords)
+        }
     }
   }
 }

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -3,9 +3,12 @@ package com.github.johnynek.bazel_deps
 import IO.{Path, Result}
 import cats.Traverse
 import cats.implicits._
+import org.slf4j.LoggerFactory
 import scala.util.{ Failure, Success, Try }
 
 object Writer {
+
+  private[this] val logger = LoggerFactory.getLogger("Writer")
 
   /**
    * Takes a BUILD file path and generated contents, and returns the formatted version of those contents (e.g. with
@@ -74,7 +77,7 @@ object Writer {
             val serverUrl = servers.getOrElse(sha.serverId, "")
             (s""", "sha1": "${hex}"""", s""", "repository": "${serverUrl}"""")
           case Some(Failure(err)) =>
-            System.err.println(s"failed to find sha of ${coord.asString}: $err")
+            logger.error(s"failed to find sha of ${coord.asString}:", err)
             throw err
           case None => ("", "")
         }


### PR DESCRIPTION
We were already including an SLF4J dependency, so all we had to do was
to start using it! This commit adds a Verbosity type, along with the
Decline machinery to be able to pass log levels as command-line
arguments.

In the future we should add verbosity to the other bazel-deps
commands, and replace all error/info reporting println's with logging
instead. (Some println's represent program output; these should
probably stay as-is.)