### PR TITLE
[wip] Kotlin support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ buildNumber.properties
 *.iml
 bazel-*
 .DS_Store
+.project

--- a/src/scala/com/github/johnynek/bazel_deps/Commands.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Commands.scala
@@ -117,6 +117,7 @@ object Command {
   implicit val langArg: Argument[Language] = new Argument[Language] {
     def defaultMetavar: String = "lang"
     def read(s: String) = s match {
+      case "kt_jvm" => Validated.valid(Language.KotlinJvm)
       case "java" => Validated.valid(Language.Java)
       case "scala" => Validated.valid(Language.Scala.default)
       case other => Validated.invalidNel(s"unknown language: $other")

--- a/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
@@ -75,6 +75,7 @@ object Decoders {
   implicit def optionsDecoder: Decoder[Options] = {
     implicit val versionLang: Decoder[Language] =
       Decoder.decodeString.emap {
+        case "kt_jvm" => Right(Language.KotlinJvm)
         case "java" => Right(Language.Java)
         case s if s.startsWith("scala:") =>
           s.split(':') match {
@@ -99,6 +100,7 @@ object Decoders {
 
       implicit val lang: Decoder[Language] =
         Decoder.decodeString.emap {
+          case "kt_jvm" => Right(Language.KotlinJvm: Language)
           case "java" => Right(Language.Java : Language)
           case "scala" =>
             opts.getLanguages

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -387,6 +387,24 @@ object Language {
     def unmangle(m: MavenCoordinate) = m
   }
 
+  case object KotlinJvm extends Language {
+    def asString = "kt_jvm"
+    def asOptionsString = asString
+    def mavenCoord(g: MavenGroup, a: ArtifactOrProject, v: Version): MavenCoordinate =
+      MavenCoordinate(g, MavenArtifactId(a), v)
+
+    def mavenCoord(g: MavenGroup, a: ArtifactOrProject, sp: Subproject, v: Version): MavenCoordinate =
+      MavenCoordinate(g, MavenArtifactId(a, sp), v)
+
+    def unversioned(g: MavenGroup, a: ArtifactOrProject): UnversionedCoordinate =
+      UnversionedCoordinate(g, MavenArtifactId(a))
+
+    def unversioned(g: MavenGroup, a: ArtifactOrProject, sp: Subproject): UnversionedCoordinate =
+      UnversionedCoordinate(g, MavenArtifactId(a, sp))
+
+    def unmangle(m: MavenCoordinate) = m
+  }
+
   case class Scala(v: Version, mangle: Boolean) extends Language {
     def asString = if (mangle) "scala" else "scala/unmangled"
     def asOptionsString: String = s"scala:${v.asString}"

--- a/src/scala/com/github/johnynek/bazel_deps/Label.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Label.scala
@@ -29,6 +29,8 @@ object Label {
     case Language.Java => Label(Some(u.toBazelRepoName(np)), Path(List("jar")), "")
     // If we know we have a scala jar, just use ":file" to be sure we can deal with macros
     case Language.Scala(_, _) => Label(Some(u.toBazelRepoName(np)), Path(List("jar")), "file")
+    // If we know we have a kotlin jar, just use ":file" to be sure we don't have ijar's generated
+    case Language.KotlinJvm => Label(Some(u.toBazelRepoName(np)), Path(List("jar")), "file")
   }
 
   def replaced(u: UnversionedCoordinate, r: Replacements): Option[(Label, Language)] =
@@ -47,6 +49,7 @@ object Label {
 
     val artName = lang match {
       case Language.Java => m.artifact.asString
+      case Language.KotlinJvm => m.artifact.asString
       case s@Language.Scala(_, true) =>
         s.removeSuffix(m.artifact.asString) match {
           case Some(n) => n

--- a/src/scala/com/github/johnynek/bazel_deps/Target.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Target.scala
@@ -78,6 +78,7 @@ case class Target(
 
     val langName = lang match {
       case Language.Java => "java"
+      case Language.KotlinJvm => "kt_jvm"
       case Language.Scala(_, _) => "scala"
     }
 

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -201,6 +201,12 @@ object Writer {
           // TODO: converge on using java_import instead of java_library:
           // https://github.com/johnynek/bazel-deps/issues/102
           lang match {
+            case Language.KotlinJvm =>
+              Target(lang,
+                kind = Target.Library,
+                name = Label.localTarget(pathInRoot, u, lang),
+                exports = Set(lab),
+                jars = Set.empty)
             case Language.Java =>
               Target(lang,
                 kind = Target.Library,
@@ -242,6 +248,12 @@ object Writer {
         // TODO: converge on using java_import instead of java_library:
         // https://github.com/johnynek/bazel-deps/issues/102
         lang match {
+          case Language.KotlinJvm =>
+            Target(lang,
+              kind = Target.Library,
+              name = Label.localTarget(pathInRoot, u, lang),
+              exports = Set(lab),
+              jars = Set.empty)
           case Language.Java =>
             Target(lang,
               kind = Target.Library,


### PR DESCRIPTION
This wip just includes the structural changes to get something generating for Kotlin artifacts.

To check if it's working just add this to the projects dependencies.yaml

```yams
  org.jetbrains.kotlinx:
    kotlinx-coroutines-core:
      lang: kt_jvm
      version : "0.22.5"
```

some issues that need consideration. 

1. The transitive dependencies of a kotlin artifact could include other kotlin artifacts, some of these will not be mentioned in `dependencies.yaml`. I assume the current behaviour -- which I haven't tested -- would be to treat these all as java dependencies or as kotlin dependencies. We can't detect the nature of the dep without deep inspection of the artifact.

2. A`kt_jvm_library` is generated currently. This should be switched to `kt_jvm_import` but `kt_jvm_import` needs to be updated it's currently only really a simple bootstrap rule (add a  single `jar` + `-sources.jar` to the project and disable ijarification). it needs to be extended to support the regular java artifact concepts such as `exports`, `exports_plugin`, `deps`, `runtime_deps`. If this is not done then we need to include two entries in the output a `kt_jvm_import` followed by a `java_library` for exporting (`kt_jvm_library` is invalid without sources currently).  Also kotlin_jvm_import [has a bug](https://github.com/bazelbuild/bazel/issues/4798) currently with triggers when `-sources.jar` are absent from the generated repository. This is triggered by 0.12.0.  [This issue](https://github.com/bazelbuild/rules_kotlin/issues/51) will fix the bug, and I might update the rule with the other required changes

I am not in favour of this approach but we need a solution now. I feel kotlin jvm artifacts do not need to be treated specially by bazel -- the only difference with a `java_library` is that the   ijarification process needs to be slightly altered. [This issue](https://github.com/bazelbuild/bazel/issues/4549) tracks the proposal to update the core ijar tool.

In conclusion more work needs to be done and I'm hoping the ijar tool gets updated which would make bazel-deps just work without any changes.