### PR TITLE
Strict visibility for generated dependencies

### DIFF
--- a/3rdparty/jvm/com/fasterxml/jackson/core/BUILD
+++ b/3rdparty/jvm/com/fasterxml/jackson/core/BUILD
@@ -5,7 +5,7 @@ java_library(
         "//external:jar/com/fasterxml/jackson/core/jackson_annotations"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/com/google/guava/BUILD
+++ b/3rdparty/jvm/com/google/guava/BUILD
@@ -5,7 +5,7 @@ java_library(
         "//external:jar/com/google/guava/guava"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/commons_codec/BUILD
+++ b/3rdparty/jvm/commons_codec/BUILD
@@ -5,7 +5,7 @@ java_library(
         "//external:jar/commons_codec/commons_codec"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/io/circe/BUILD
+++ b/3rdparty/jvm/io/circe/BUILD
@@ -82,7 +82,7 @@ scala_import(
         "//3rdparty/jvm/org/scala_lang:scala_library"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/apache/commons/BUILD
+++ b/3rdparty/jvm/org/apache/commons/BUILD
@@ -5,7 +5,7 @@ java_library(
         "//external:jar/org/apache/commons/commons_lang3"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/apache/httpcomponents/BUILD
+++ b/3rdparty/jvm/org/apache/httpcomponents/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":httpcore"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 
@@ -21,7 +21,7 @@ java_library(
         "//external:jar/org/apache/httpcomponents/httpcore"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/apache/maven/BUILD
+++ b/3rdparty/jvm/org/apache/maven/BUILD
@@ -33,7 +33,7 @@ java_library(
         "//3rdparty/jvm/org/codehaus/plexus:plexus_utils"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 
@@ -49,7 +49,7 @@ java_library(
         "//3rdparty/jvm/org/codehaus/plexus:plexus_utils"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 
@@ -65,7 +65,7 @@ java_library(
         "//3rdparty/jvm/org/codehaus/plexus:plexus_utils"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 
@@ -87,7 +87,7 @@ java_library(
         ":maven_model"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 
@@ -102,7 +102,7 @@ java_library(
         "//3rdparty/jvm/org/codehaus/plexus:plexus_utils"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/codehaus/plexus/BUILD
+++ b/3rdparty/jvm/org/codehaus/plexus/BUILD
@@ -5,7 +5,7 @@ java_library(
         "//external:jar/org/codehaus/plexus/plexus_component_annotations"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 
@@ -17,7 +17,7 @@ java_library(
         "//external:jar/org/codehaus/plexus/plexus_interpolation"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 
@@ -29,7 +29,7 @@ java_library(
         "//external:jar/org/codehaus/plexus/plexus_utils"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/eclipse/aether/BUILD
+++ b/3rdparty/jvm/org/eclipse/aether/BUILD
@@ -105,7 +105,7 @@ java_library(
         ":aether_api"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/scala_lang/BUILD
+++ b/3rdparty/jvm/org/scala_lang/BUILD
@@ -5,7 +5,7 @@ scala_library(
         "@scala//:scala-compiler"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 
@@ -17,7 +17,7 @@ scala_library(
         "@scala//:scala-library"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 
@@ -29,7 +29,7 @@ scala_library(
         "@scala//:scala-reflect"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/scala_lang/modules/BUILD
+++ b/3rdparty/jvm/org/scala_lang/modules/BUILD
@@ -5,7 +5,7 @@ scala_library(
         "@scala//:scala-parser-combinators"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/scala_sbt/BUILD
+++ b/3rdparty/jvm/org/scala_sbt/BUILD
@@ -5,7 +5,7 @@ java_library(
         "//external:jar/org/scala_sbt/test_interface"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/slf4j/BUILD
+++ b/3rdparty/jvm/org/slf4j/BUILD
@@ -8,7 +8,7 @@ java_library(
         ":slf4j_api"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/spire_math/BUILD
+++ b/3rdparty/jvm/org/spire_math/BUILD
@@ -8,7 +8,7 @@ scala_import(
         "//3rdparty/jvm/org/scala_lang:scala_library"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/typelevel/BUILD
+++ b/3rdparty/jvm/org/typelevel/BUILD
@@ -81,7 +81,7 @@ scala_import(
         "//3rdparty/jvm/org/scala_lang:scala_reflect"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/jvm/org/yaml/BUILD
+++ b/3rdparty/jvm/org/yaml/BUILD
@@ -5,7 +5,7 @@ java_library(
         "//external:jar/org/yaml/snakeyaml"
     ],
     visibility = [
-        "//visibility:public"
+        "//3rdparty/jvm:__subpackages__"
     ]
 )
 

--- a/3rdparty/workspace.bzl
+++ b/3rdparty/workspace.bzl
@@ -60,7 +60,7 @@ def list_dependencies():
     {"artifact": "org.eclipse.aether:aether-api:1.1.0", "lang": "java", "sha1": "05dd291e788f50dfb48822dab29defc16ad70860", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_aether_aether_api", "actual": "@org_eclipse_aether_aether_api//jar", "bind": "jar/org/eclipse/aether/aether_api"},
     {"artifact": "org.eclipse.aether:aether-connector-basic:1.1.0", "lang": "java", "sha1": "f5c784bdd704ff64166c086eb6b31e2784c87b66", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_aether_aether_connector_basic", "actual": "@org_eclipse_aether_aether_connector_basic//jar", "bind": "jar/org/eclipse/aether/aether_connector_basic"},
     {"artifact": "org.eclipse.aether:aether-impl:1.1.0", "lang": "java", "sha1": "8236fde6a1a4a7c6018d0a09e476f11c5ca8c2e1", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_eclipse_aether_aether_impl", "actual": "@org_eclipse_aether_aether_impl//jar", "bind": "jar/org/eclipse/aether/aether_impl"},
-# duplicates in org.eclipse.aether:aether-spi promoted to 1.1.0
+# duplicates in org.eclipse.aether:aether-spi fixed to 1.1.0
 # - org.apache.maven:maven-aether-provider:3.3.9 wanted version 1.0.2.v20150114
 # - org.eclipse.aether:aether-connector-basic:1.1.0 wanted version 1.1.0
 # - org.eclipse.aether:aether-impl:1.1.0 wanted version 1.1.0
@@ -81,7 +81,7 @@ def list_dependencies():
     {"artifact": "org.scalactic:scalactic_2.11:3.0.1", "lang": "scala", "sha1": "3c444d143879dc172fa555cea08fd0de6fa2f34f", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_scalactic_scalactic_2_11", "actual": "@org_scalactic_scalactic_2_11//jar:file", "bind": "jar/org/scalactic/scalactic_2_11"},
     {"artifact": "org.scalatest:scalatest_2.11:3.0.1", "lang": "scala", "sha1": "40a1842e7f0b915d87de1cb69f9c6962a65ee1fd", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_scalatest_scalatest_2_11", "actual": "@org_scalatest_scalatest_2_11//jar:file", "bind": "jar/org/scalatest/scalatest_2_11"},
     {"artifact": "org.slf4j:jcl-over-slf4j:1.6.2", "lang": "java", "sha1": "ac4cd2d6d0cf4342b4e8fd520c686851fc681912", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_slf4j_jcl_over_slf4j", "actual": "@org_slf4j_jcl_over_slf4j//jar", "bind": "jar/org/slf4j/jcl_over_slf4j"},
-# duplicates in org.slf4j:slf4j-api promoted to 1.7.25
+# duplicates in org.slf4j:slf4j-api fixed to 1.7.25
 # - org.slf4j:jcl-over-slf4j:1.6.2 wanted version 1.6.2
 # - org.slf4j:slf4j-simple:1.7.25 wanted version 1.7.25
     {"artifact": "org.slf4j:slf4j-api:1.7.25", "lang": "java", "sha1": "da76ca59f6a57ee3102f8f9bd9cee742973efa8a", "repository": "https://repo.maven.apache.org/maven2/", "name": "org_slf4j_slf4j_api", "actual": "@org_slf4j_slf4j_api//jar", "bind": "jar/org/slf4j/slf4j_api"},

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ In any case, we add a comment for any duplicates found in the workspace loading 
 
 To declare dependencies, add items to the `dependencies` key in your declaration file. The format
 should be yaml or json. It should have [`dependencies`](#dependencies) and it may have [`replacements`](#replacements)
-and [`options`](#options).
+and [`options`](#options). Important: only dependencies explicitly named have public visibility,
+transitive dependencies not listed in the dependencies file have visibility limited to the third
+party directory.
 
 ### <a name="dependencies">Dependencies</a>
 
@@ -64,6 +66,10 @@ dependencies:
       lang: scala
       modules: [core, date, args, db, arvo]
 ```
+The `version` field is optional. If it is absent, it means this jar is expected to be found by
+transitive dependencies, and it is available to be used outside of the thirdparty directory, but the
+exact version used can be selected according to the version resolution rules. It is an error to have
+an unversioned dependency that is not a transitive dependency of another versioned dependency.
 
 A target may optionally add `exports` and `exclude` lists to a dependency. `exports` should be just the group and
 artifact (such as: `com.twitter:scalding-core` in the above), and they should be listed in the dependencies. `exclude`

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -14,6 +14,11 @@ dependencies:
     shapeless:
       lang: scala
 
+  com.fasterxml.jackson.core:
+    jackson:
+      lang: java
+      modules: [ "core", "databind" ]
+
   com.fasterxml.jackson.dataformat:
     jackson-dataformat-yaml:
       lang: java
@@ -28,7 +33,7 @@ dependencies:
   io.circe:
     circe:
       lang: scala
-      modules: [ "core", "jackson25", "parser" ]
+      modules: [ "core", "jackson25", "jawn", "parser" ]
       version: "0.8.0"
     circe-generic:
       exports:
@@ -53,7 +58,7 @@ dependencies:
   org.eclipse.aether:
     aether:
       lang: java
-      modules: [ "api", "connector-basic", "impl", "transport-file", "transport-http" ]
+      modules: [ "api", "connector-basic", "impl", "spi", "transport-file", "transport-http" ]
       version: "1.1.0"
 
   org.scala-lang.modules:
@@ -79,8 +84,9 @@ dependencies:
       version: "3.0.1"
 
   org.slf4j:
-    slf4j-simple:
+    slf4j:
       lang: java
+      modules: [ "api", "simple" ]
       version: "1.7.25"
 
   org.spire-math:

--- a/src/scala/com/github/johnynek/bazel_deps/Label.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Label.scala
@@ -3,16 +3,21 @@ package com.github.johnynek.bazel_deps
 import IO.Path
 
 case class Label(workspace: Option[String], path: Path, name: String) {
-  def asStringFrom(p: Path): String = {
-    val nmPart = if (name.isEmpty) "" else s":$name"
-    if (workspace.isEmpty && path == p) nmPart
-    else {
-      val ws = workspace.fold("") { nm => s"@$nm" }
-      path.parts match {
-        case Nil => s"$ws//$nmPart"
-        case ps => ps.mkString(s"$ws//", "/", s"$nmPart")
-      }
+  def packageLabel: Label = Label(workspace, path, "")
+
+  private[this] val nmPart = if (name.isEmpty) "" else s":$name"
+
+  def fromRoot: String = {
+    val ws = workspace.fold("") { nm => s"@$nm" }
+    path.parts match {
+      case Nil => s"$ws//$nmPart"
+      case ps => ps.mkString(s"$ws//", "/", nmPart)
     }
+  }
+
+  def asStringFrom(p: Path): String = {
+    if (workspace.isEmpty && path == p) nmPart
+    else fromRoot
   }
 }
 

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -39,8 +39,6 @@ object MakeDeps {
         logger.error("resolution and sha collection failed", err)
         System.exit(1)
       case Success((normalized, shas, duplicates)) =>
-        // build the workspace
-        def ws = Writer.workspace(g.depsFile, normalized, duplicates, shas, model)
         // build the BUILDs in thirdParty
         val targets = Writer.targets(normalized, model) match {
           case Right(t) => t
@@ -77,6 +75,8 @@ object MakeDeps {
           case None => (_, s) => s
         }
 
+        // build the workspace
+        val ws = Writer.workspace(g.depsFile, normalized, duplicates, shas, model)
         if (g.checkOnly) {
           executeCheckOnly(model, projectRoot, IO.path(workspacePath), ws, targets, formatter)
         } else {

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -214,8 +214,10 @@ object Writer {
 
       val rootName = model.getOptions.getThirdPartyDirectory
       val thirdPartyVis = Target.Visibility.SubPackages(Label(None, Path(rootName.parts), ""))
+
+      val allRootsUv = model.dependencies.roots.map(_.unversioned) | model.dependencies.unversionedRoots
       def visibility(uv: UnversionedCoordinate): Target.Visibility =
-        if (model.dependencies.unversionedRoots(uv)) Target.Visibility.Public
+        if (allRootsUv(uv)) Target.Visibility.Public
         else thirdPartyVis
 
       /**

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -116,7 +116,7 @@ object Writer {
         List(s"""$comment    {${kv("artifact", coord.asString)}""",
              s"""${kv("lang", l.asString)}$shaStr$serverStr""",
              s"""${kv("name", coord.unversioned.toBazelRepoName(prefix))}""",
-             s"""${kv("actual", actual.asStringFrom(Path(Nil)))}""",
+             s"""${kv("actual", actual.fromRoot)}""",
              s"""${kv("bind", coord.unversioned.toBindingName(prefix))}},""").mkString(", ")
       }
       .mkString("\n")
@@ -212,12 +212,17 @@ object Writer {
        */
       val uvToRep = model.getReplacements.unversionedToReplacementRecord
 
+      val rootName = model.getOptions.getThirdPartyDirectory
+      val thirdPartyVis = Target.Visibility.SubPackages(Label(None, Path(rootName.parts), ""))
+      def visibility(uv: UnversionedCoordinate): Target.Visibility =
+        if (model.dependencies.unversionedRoots(uv)) Target.Visibility.Public
+        else thirdPartyVis
+
       /**
        * Here are all the unversioned artifacts we need to create targets for:
        */
       val allUnversioned: Set[UnversionedCoordinate] = uvToVerExplicit.keySet.union(uvToRep.keySet)
 
-      val rootName = model.getOptions.getThirdPartyDirectory
       val licenses = model.getOptions.getLicenses
       val pathInRoot = rootName.parts
 
@@ -231,12 +236,14 @@ object Writer {
               Target(lang,
                 kind = Target.Library,
                 name = Label.localTarget(pathInRoot, u, lang),
+                visibility = visibility(u),
                 exports = Set(lab),
                 jars = Set.empty)
             case _: Language.Scala =>
               Target(lang,
                 kind = Target.Library,
                 name = Label.localTarget(pathInRoot, u, lang),
+                visibility = visibility(u),
                 exports = Set(lab),
                 jars = Set.empty)
           }
@@ -282,6 +289,7 @@ object Writer {
                     Target(lang,
                       kind = Target.Library,
                       name = Label.localTarget(pathInRoot, u, lang),
+                      visibility = visibility(u),
                       exports = (exports + lab) ++ uvexports,
                       jars = Set.empty,
                       runtimeDeps = runtime_deps -- uvexports,
@@ -291,6 +299,7 @@ object Writer {
                     Target(lang,
                       kind = Target.Import,
                       name = Label.localTarget(pathInRoot, u, lang),
+                      visibility = visibility(u),
                       exports = exports ++ uvexports,
                       jars = Set(lab),
                       runtimeDeps = runtime_deps -- uvexports,

--- a/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
@@ -296,6 +296,7 @@ maven_dependencies(maven_load)
         labelFor(proj, "main").map { lab =>
           Target(scalaLang,
             lab,
+            visibility = Target.Visibility.Public,
             deps = labs.toSet,
             sources = Target.SourceList.Globs(List("src/main/**/*.scala", "src/main/**/*.java")))
         }


### PR DESCRIPTION
This solves issue #99  (again)...

Sadly, I had lost track that @arjantop had already submitted a PR on this. I apologize. I took a slightly different take, but not much different. That said, looking back, I like this a bit better: keeping Target more generic and keeping the smarts about setting visibility in Writer, which is already keeping state about how to map maven dependency graphs into bazel.

Currently, it is always on. I could make it an option, but I am on the fence about that. I think maybe an option to turn it off, but by default require it.

We have seen several issues with people using incidental transitive dependencies that break when we update versions.

This required several rounds to update even this small repo, so it probably means that upgrading a big repo will require an hour or two of work, but I am reluctant to keep adding options for unsafe behavior.

cc @ianoc-stripe @ianoc @kamalmarhubi @arjantop 
