### PR TITLE
Add a backend to download sources and primary jars and 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ buildNumber.properties
 *.iml
 bazel-*
 .DS_Store
+.project/**

--- a/3rdparty/workspace.bzl
+++ b/3rdparty/workspace.bzl
@@ -1,16 +1,68 @@
 # Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+def _jar_artifact_impl(ctx):
+    jar_name = "%s.jar" % ctx.name
+    ctx.download(
+        output=ctx.path("jar/%s" % jar_name),
+        url=ctx.attr.urls,
+        sha256=ctx.attr.sha256,
+        executable=False
+    )
+    src_name="%s-sources.jar" % ctx.name
+    srcjar_attr=""
+    has_sources = len(ctx.attr.src_urls) != 0
+    if has_sources:
+        ctx.download(
+            output=ctx.path("jar/%s" % src_name),
+            url=ctx.attr.src_urls,
+            sha256=ctx.attr.src_sha256,
+            executable=False
+        )
+        srcjar_attr ='\n    srcjar = ":%s",' % src_name
 
-def declare_maven(hash):
-    native.maven_jar(
-        name = hash["name"],
+    build_file_contents = """
+package(default_visibility = ['//visibility:public'])
+java_import(
+    name = 'jar',
+    jars = ['{jar_name}'],{srcjar_attr}
+)
+filegroup(
+    name = 'file',
+    srcs = [
+        '{jar_name}',
+        '{src_name}'
+    ],
+    visibility = ['//visibility:public']
+)\n""".format(jar_name = jar_name, src_name = src_name, srcjar_attr = srcjar_attr)
+    ctx.file(ctx.path("jar/BUILD"), build_file_contents, False)
+    return None
+
+jar_artifact = repository_rule(
+    attrs = {
+        "artifact": attr.string(mandatory = True),
+        "sha256": attr.string(mandatory = True),
+        "urls": attr.string_list(mandatory = True),
+        "src_sha256": attr.string(mandatory = False, default=""),
+        "src_urls": attr.string_list(mandatory = False, default=[]),
+    },
+    implementation = _jar_artifact_impl
+)
+
+def jar_artifact_callback(hash):
+    src_urls = []
+    src_sha256 = ""
+    source=hash.get("source", None)
+    if source != None:
+        src_urls = [source["url"]]
+        src_sha256 = source["sha256"]
+    jar_artifact(
         artifact = hash["artifact"],
-        sha1 = hash["sha1"],
-        repository = hash["repository"]
+        name = hash["name"],
+        urls = [hash["url"]],
+        sha256 = hash["sha256"],
+        src_urls = src_urls,
+        src_sha256 = src_sha256
     )
-    native.bind(
-        name = hash["bind"],
-        actual = hash["actual"]
-    )
+    native.bind(name = hash["bind"], actual = hash["actual"])
 
 def list_dependencies():
     return [
@@ -105,6 +157,6 @@ def list_dependencies():
     {"artifact": "org.yaml:snakeyaml:1.12", "lang": "java", "sha1": "ebe66a6b88caab31d7a19571ad23656377523545", "sha256": "0699c809d1644b6a8209e700763bf59497df3e63756bb22f52e331e2c7e750a8", "repository": "https://repo.maven.apache.org/maven2/", "url": "https://repo.maven.apache.org/maven2/org/yaml/snakeyaml/1.12/snakeyaml-1.12.jar", "source": {"sha1": "f86c67beb22f7d1edb5d6c6a3c4dab77a23234da", "sha256": "363e9e69b052ebae3dbb0103f55180cc78971457e0da4155bb871a559c12be30", "repository": "https://repo.maven.apache.org/maven2/", "url": "https://repo.maven.apache.org/maven2/org/yaml/snakeyaml/1.12/snakeyaml-1.12-sources.jar"} , "name": "org_yaml_snakeyaml", "actual": "@org_yaml_snakeyaml//jar", "bind": "jar/org/yaml/snakeyaml"},
     ]
 
-def maven_dependencies(callback = declare_maven):
+def maven_dependencies(callback = jar_artifact_callback):
     for hash in list_dependencies():
         callback(hash)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -2,6 +2,7 @@ options:
   buildHeader: [ "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")" ]
   languages: [ "java", "scala:2.11.8" ]
   resolverType: "coursier"
+  strictDeps: true
   resolvers:
     - id: "mavencentral"
       type: "default"

--- a/src/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/src/scala/com/github/johnynek/bazel_deps/BUILD
@@ -132,6 +132,8 @@ scala_binary(name = "parseproject",
                  ":commands",
                  "//3rdparty/jvm/org/slf4j:slf4j_simple",
              ],
+             resources = ["templates/jar_artifact_backend.bzl"],
+             resource_strip_prefix = PACKAGE_NAME,
              main_class = "com.github.johnynek.bazel_deps.ParseProject",
              visibility = ["//visibility:public"])
 

--- a/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Decoders.scala
@@ -5,6 +5,7 @@ import io.circe.{ Decoder, KeyDecoder, Json, Error, Parser }
 import io.circe.generic.auto
 
 object Decoders {
+  implicit val strictVisibilityDecoder: Decoder[StrictVisibility] =  Decoder.decodeBoolean.map(x => StrictVisibility(x))
   implicit val versionDecoder: Decoder[Version] = stringWrapper(Version(_))
   implicit val processorClassDecoder: Decoder[ProcessorClass] = stringWrapper(ProcessorClass(_))
   implicit val subprojDecoder: Decoder[Subproject] = stringWrapper(Subproject(_))

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -234,6 +234,7 @@ object Writer {
       val allRootsUv = model.dependencies.roots.map(_.unversioned) | model.dependencies.unversionedRoots
       def visibility(uv: UnversionedCoordinate): Target.Visibility =
         if (allRootsUv(uv)) Target.Visibility.Public
+        else if( ! model.options.flatMap { _.strictVisibility.map(_.enabled) }.getOrElse(true)) Target.Visibility.Public
         else thirdPartyVis
 
       /**

--- a/src/scala/com/github/johnynek/bazel_deps/templates/jar_artifact_backend.bzl
+++ b/src/scala/com/github/johnynek/bazel_deps/templates/jar_artifact_backend.bzl
@@ -1,0 +1,64 @@
+def _jar_artifact_impl(ctx):
+    jar_name = "%s.jar" % ctx.name
+    ctx.download(
+        output=ctx.path("jar/%s" % jar_name),
+        url=ctx.attr.urls,
+        sha256=ctx.attr.sha256,
+        executable=False
+    )
+    src_name="%s-sources.jar" % ctx.name
+    srcjar_attr=""
+    has_sources = len(ctx.attr.src_urls) != 0
+    if has_sources:
+        ctx.download(
+            output=ctx.path("jar/%s" % src_name),
+            url=ctx.attr.src_urls,
+            sha256=ctx.attr.src_sha256,
+            executable=False
+        )
+        srcjar_attr ='\n    srcjar = ":%s",' % src_name
+
+    build_file_contents = """
+package(default_visibility = ['//visibility:public'])
+java_import(
+    name = 'jar',
+    jars = ['{jar_name}'],{srcjar_attr}
+)
+filegroup(
+    name = 'file',
+    srcs = [
+        '{jar_name}',
+        '{src_name}'
+    ],
+    visibility = ['//visibility:public']
+)\n""".format(jar_name = jar_name, src_name = src_name, srcjar_attr = srcjar_attr)
+    ctx.file(ctx.path("jar/BUILD"), build_file_contents, False)
+    return None
+
+jar_artifact = repository_rule(
+    attrs = {
+        "artifact": attr.string(mandatory = True),
+        "sha256": attr.string(mandatory = True),
+        "urls": attr.string_list(mandatory = True),
+        "src_sha256": attr.string(mandatory = False, default=""),
+        "src_urls": attr.string_list(mandatory = False, default=[]),
+    },
+    implementation = _jar_artifact_impl
+)
+
+def jar_artifact_callback(hash):
+    src_urls = []
+    src_sha256 = ""
+    source=hash.get("source", None)
+    if source != None:
+        src_urls = [source["url"]]
+        src_sha256 = source["sha256"]
+    jar_artifact(
+        artifact = hash["artifact"],
+        name = hash["name"],
+        urls = [hash["url"]],
+        sha256 = hash["sha256"],
+        src_urls = src_urls,
+        src_sha256 = src_sha256
+    )
+    native.bind(name = hash["bind"], actual = hash["actual"])


### PR DESCRIPTION
The `maven_jar` in Bazel 0.15 doesn't accept source hashes yet even though the documentation indicates that it does.  

Add an option to disable strict deps.