### PR TITLE
Include a tag with the jar's maven_coordinates

### DIFF
--- a/3rdparty/workspace.bzl
+++ b/3rdparty/workspace.bzl
@@ -23,6 +23,7 @@ def _jar_artifact_impl(ctx):
 package(default_visibility = ['//visibility:public'])
 java_import(
     name = 'jar',
+    tags = ['maven_coordinates={artifact}'],
     jars = ['{jar_name}'],{srcjar_attr}
 )
 filegroup(
@@ -32,7 +33,7 @@ filegroup(
         '{src_name}'
     ],
     visibility = ['//visibility:public']
-)\n""".format(jar_name = jar_name, src_name = src_name, srcjar_attr = srcjar_attr)
+)\n""".format(artifact = ctx.attr.artifact, jar_name = jar_name, src_name = src_name, srcjar_attr = srcjar_attr)
     ctx.file(ctx.path("jar/BUILD"), build_file_contents, False)
     return None
 
@@ -63,6 +64,7 @@ def jar_artifact_callback(hash):
         src_sha256 = src_sha256
     )
     native.bind(name = hash["bind"], actual = hash["actual"])
+
 
 def list_dependencies():
     return [

--- a/src/scala/com/github/johnynek/bazel_deps/templates/jar_artifact_backend.bzl
+++ b/src/scala/com/github/johnynek/bazel_deps/templates/jar_artifact_backend.bzl
@@ -22,6 +22,7 @@ def _jar_artifact_impl(ctx):
 package(default_visibility = ['//visibility:public'])
 java_import(
     name = 'jar',
+    tags = ['maven_coordinates={artifact}'],
     jars = ['{jar_name}'],{srcjar_attr}
 )
 filegroup(
@@ -31,7 +32,7 @@ filegroup(
         '{src_name}'
     ],
     visibility = ['//visibility:public']
-)\n""".format(jar_name = jar_name, src_name = src_name, srcjar_attr = srcjar_attr)
+)\n""".format(artifact = ctx.attr.artifact, jar_name = jar_name, src_name = src_name, srcjar_attr = srcjar_attr)
     ctx.file(ctx.path("jar/BUILD"), build_file_contents, False)
     return None
 


### PR DESCRIPTION
This can then be used by something like
https://github.com/google/bazel-common/blob/master/tools/maven/pom_file.bzl
to know the imported maven dependencies when writing their OWN poms.