### PR TITLE
Handle paths for labels correctly

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/Label.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Label.scala
@@ -10,7 +10,9 @@ case class Label(workspace: Option[String], path: Path, name: String) {
   def fromRoot: String = {
     val ws = workspace.fold("") { nm => s"@$nm" }
     path.parts match {
-      case Nil => s"$ws//$nmPart"
+      case Nil =>
+        if (nmPart.isEmpty) ws
+        else s"$ws//$nmPart"
       case ps => ps.mkString(s"$ws//", "/", nmPart)
     }
   }
@@ -27,8 +29,13 @@ object Label {
     val wsLen = ws.fold(0)(_.length)
     val pathAndTarg = str.drop(1 + wsLen).dropWhile(_ == '/')
     val pathStr = pathAndTarg.takeWhile(_ != ':')
+
+    val path =
+      if (pathStr.isEmpty) Path(List())
+      else Path(pathStr.split('/').toList)
+
     val target = pathAndTarg.drop(1 + pathStr.length)
-    Label(ws, Path(pathStr.split('/').toList), target)
+    Label(ws, path, target)
   }
   def externalJar(lang: Language, u: UnversionedCoordinate, np: NamePrefix): Label = lang match {
     case Language.Java => Label(Some(u.toBazelRepoName(np)), Path(List("jar")), "")


### PR DESCRIPTION
In bazel the target `@some_label` is resolved as `@some_label//:some_label`.

When specifying replacements using this format, e.g.:
```yaml
replacements:
  org.scala-lang.modules:
    scala-parser-combinators:
      lang: scala
      target:
        "@io_bazel_rules_scala_scala_parser_combinators"
```
the exports in the created BUILD file looks like `@io_bazel_rules_scala_scala_parser_combinators//`. This is not the same as `@io_bazel_rules_scala_scala_parser_combinators` and thus doesn't work.

This makes a target `@some_label` resolve to `@some_label` instead of `@some_label//` by:

- making the path of a`Label` an empty list instead of a list containing an empty string if there is no path
- Adding a case to `fromRoot` for when the `Label` has no name and an empty path

Didn't find any direct tests for `Label`, should I add something / add a test somewhere else?

@johnynek 



