### PR TITLE
Add test configuration to the bazelproject

### DIFF
--- a/ij.bazelproject
+++ b/ij.bazelproject
@@ -11,3 +11,6 @@ test_sources:
 
 additional_languages:
   scala
+
+import_run_configurations:
+  test/all_tests.xml

--- a/test/all_tests.xml
+++ b/test/all_tests.xml
@@ -1,0 +1,5 @@
+<configuration name="All Tests" type="BlazeCommandRunConfigurationType" factoryName="Bazel Command" nameIsGenerated="false">
+    <blaze-settings handler-id="BlazeCommandGenericRunConfigurationHandlerProvider" blaze-command="test">
+        <blaze-target>//test/scala/com/github/johnynek/bazel_deps:all_tests</blaze-target>
+    </blaze-settings>
+</configuration>

--- a/test/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/test/scala/com/github/johnynek/bazel_deps/BUILD
@@ -97,3 +97,5 @@ scala_test(name = "coursier_test",
                "//src/scala/com/github/johnynek/bazel_deps:makedeps",
                "//src/scala/com/github/johnynek/bazel_deps:graph",
                ])
+
+test_suite(name = "all_tests")


### PR DESCRIPTION
Setup the ij project so that all tests are available as a standard run configuration.