### PR TITLE
Set licenses on replacement libraries

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -257,14 +257,16 @@ object Writer {
                 name = Label.localTarget(pathInRoot, u, lang),
                 visibility = visibility(u),
                 exports = Set(lab),
-                jars = Set.empty)
+                jars = Set.empty,
+                licenses = licenses)
             case _: Language.Scala =>
               Target(lang,
                 kind = Target.Library,
                 name = Label.localTarget(pathInRoot, u, lang),
                 visibility = visibility(u),
                 exports = Set(lab),
-                jars = Set.empty)
+                jars = Set.empty,
+                licenses = licenses)
           }
 
         }


### PR DESCRIPTION
This allows BUILD file dependencies on the third-party targets generated
from replacements as a uniform way of accessing dependencies.

This closes #188.