### PR TITLE
Include dependencies in java_plugin targets

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/Target.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Target.scala
@@ -117,7 +117,7 @@ case class Target(
 
     def renderPlugin(pcs: Set[ProcessorClass], pc: ProcessorClass, exports: Set[Label], licenses: Set[String]): Doc =
       sortKeys(Doc.text("java_plugin"), getPluginTargetName(pcs, pc), List(
-        "deps" -> labelList(exports ++ jars),
+        "deps" -> labelList(exports ++ jars ++ deps ++ runtimeDeps),
         "licenses" -> renderLicenses(licenses),
         "processor_class" -> quote(pc.asString),
         visibilityDoc


### PR DESCRIPTION
It is likely that the processor class requires the dependencies in order
to execute, so the JARs should be included.

This closes #189.