### PR TITLE
Having Cache.fetch try fetch the Sha-256 here makes it always run the…

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/CoursierResolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CoursierResolver.scala
@@ -153,7 +153,7 @@ class CoursierResolver(servers: List[MavenServer], ec: ExecutionContext, runTime
 
       val module = coursier.Module(c.group.asString, c.artifact.artifactId, Map.empty)
       val version = c.version.asString
-      val f = Cache.fetch[Task](checksums = Seq(Some("SHA-1"), Some("SHA-256"), None), cachePolicy = CachePolicy.FetchMissing, pool = CoursierResolver.downloadPool)
+      val f = Cache.fetch[Task](checksums = Seq(Some("SHA-1"), None), cachePolicy = CachePolicy.FetchMissing, pool = CoursierResolver.downloadPool)
       val task = Fetch.find[Task](repos, module, version, f).run
 
       /*


### PR DESCRIPTION
… query which is super slow

Caching not having a sha256 is hard, so this is pretty rough on things.

@natthu-stripe -- can you confirm if this makes the issue for you clear up?