### PR TITLE
Improve performance by fetching artifacts in parallel and fixing SHA-1 downloads

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/CoursierResolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CoursierResolver.scala
@@ -1,11 +1,12 @@
 package com.github.johnynek.bazel_deps
 
-import coursier.{Fetch, Cache, CachePolicy, Resolution, Artifact, Dependency, Project}
-import coursier.util.{Task, Schedulable}
-import cats.{Monad, MonadError, Traverse}
+import coursier.{Artifact, Cache, CachePolicy, Dependency, Fetch, Project, Resolution}
+import coursier.util.{Schedulable, Task}
+import cats.{MonadError}
 import cats.data.{Nested, NonEmptyList, Validated, ValidatedNel}
 import cats.implicits._
 import org.slf4j.LoggerFactory
+
 import scala.collection.immutable.SortedMap
 import scala.util.{Failure, Try}
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -69,18 +70,21 @@ class CoursierResolver(servers: List[MavenServer], ec: ExecutionContext, runTime
           case (None, a) => downloadSha(digestType, a)
         }
 
-      def downloadSha(digestType: DigestType, a: coursier.Artifact): Task[Option[ShaValue]] =
-        Cache.file[Task](a, cachePolicy = CachePolicy.FetchMissing, pool = CoursierResolver.downloadPool).run.map {
+      def downloadSha(digestType: DigestType, a: coursier.Artifact): Task[Option[ShaValue]] = {
+        // Because Cache.file is hijacked to download SHAs directly (rather than signed artifacts) checksum verification
+        // is turned off. Checksums don't themselves have checksum files.
+        Cache.file[Task](a, checksums = Seq(None), cachePolicy = CachePolicy.FetchMissing, pool = CoursierResolver.downloadPool).run.map {
           case Left(error) =>
             logger.info(s"failure to download ${a.url}, ${error.describe}")
             None
           case Right(file) =>
             val o = ShaValue.parseFile(digestType, file).toOption
             o.foreach { r =>
-              logger.info(s"SHA-1 for ${c.asString} downloaded from ${a.url} (${r.toHex})")
+              logger.info(s"$digestType for ${c.asString} downloaded from ${a.url} (${r.toHex})")
             }
             o
         }
+      }
 
       def computeSha(digestType: DigestType, artifact: coursier.Artifact): Task[ShaValue] =
         Cache.file[Task](artifact, cachePolicy = CachePolicy.FetchMissing, pool = CoursierResolver.downloadPool).run.flatMap { e =>
@@ -102,6 +106,20 @@ class CoursierResolver(servers: List[MavenServer], ec: ExecutionContext, runTime
         resolverMonad.handleErrorWith(computeSha(digestType, as.head))(errorFn)
       }
 
+      def fetchOrComputeShas(artifacts: NonEmptyList[Artifact], digestType: DigestType): Task[ShaValue] = {
+        val checksumArtifacts = artifacts.toList.flatMap { a =>
+          a.checksumUrls.get(digestType.name).map(url => Artifact(url, Map.empty, Map.empty, a.attributes, false, None))
+        }
+
+        downloadShas(digestType, checksumArtifacts).flatMap {
+          case Some(s) => Task.point(s)
+          case None => {
+            logger.info(s"Preforming cached fetch to execute $digestType calculation for ${artifacts.head.url}")
+            computeShas(digestType, artifacts)
+          }
+        }
+      }
+
       def processArtifact(src: Artifact.Source, dep: Dependency, proj: Project): Task[Option[JarDescriptor]] = {
           // TODO, this does not seem like the idea thing, but it seems to work.
           val maybeArtifacts = src.artifacts(dep, proj, None)
@@ -110,44 +128,20 @@ class CoursierResolver(servers: List[MavenServer], ec: ExecutionContext, runTime
             .toList
 
           NonEmptyList.fromList(maybeArtifacts).map { artifacts =>
-
-            val sha1 = downloadShas(DigestType.Sha1, maybeArtifacts.flatMap(_.extra.get("SHA-1"))).flatMap {
-              case Some(s) => Task.point(s)
-              case None => {
-                logger.info(s"Preforming cached fetch to execute SHA-1 calculation for ${artifacts.head}")
-                computeShas(DigestType.Sha1, artifacts)
-              }
-            }
-
-            // Coursier has some artifact data in extra for checksums, but has a far more complete
-            // checksumUrls attribute
-            //
-            // The SHA-1 availability as an artifact appears to be far more complete, so we only do this
-            // for the SHA-256
-            val sha256Artifacts = maybeArtifacts.flatMap(_.extra.get("SHA-256")) match {
-              case Nil =>
-                maybeArtifacts.flatMap { a =>
-                  a.checksumUrls.get("SHA-256").map{u => a.copy(url = u)}
-                }
-              case o => o
-            }
-
-            val sha256 = downloadShas(DigestType.Sha256, sha256Artifacts).flatMap {
-              case Some(s) => Task.point(s)
-              case None =>{
-                logger.info(s"Preforming cached fetch to execute SHA-256 calculation for ${artifacts.head}")
-                computeShas(DigestType.Sha256, artifacts)
-              }
-            }
-
-            (for {
-              sha1 <- sha1
-              sha256 <- sha256
+            for {
+              sha1 <- fetchOrComputeShas(artifacts, DigestType.Sha1)
+              // I could not find any example of artifacts that actually have a SHA256 checksum, so don't bother
+              // trying to fetch them. Save on network latency and just calculate.
+              sha256 <- computeShas(DigestType.Sha256, artifacts)
             } yield {
               val serverId = serverFor(artifacts.head).fold("")(_.id)
 
-              Some(JarDescriptor(sha1 = Some(sha1),sha256 = Some(sha256),serverId = serverId, url = Some(artifacts.head.url))) : Option[JarDescriptor]
-            })
+              Some(JarDescriptor(
+                sha1 = Some(sha1),
+                sha256 = Some(sha256),
+                serverId = serverId,
+                url = Some(artifacts.head.url))) : Option[JarDescriptor]
+            }
       }.getOrElse(Task.point(Option.empty[JarDescriptor]))
     }
 

--- a/src/scala/com/github/johnynek/bazel_deps/CoursierResolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CoursierResolver.scala
@@ -200,7 +200,7 @@ class CoursierResolver(servers: List[MavenServer], ec: ExecutionContext, runTime
     val g: MavenCoordinate => N[(MavenCoordinate, ResolvedShasValue)] =
       x => lookup(x).map(x -> _)
 
-    Traverse[List].traverse(m)(g).value.flatMap {
+    Task.gather.gather(m.map(x => g(x).value)).map(_.toList.sequence).flatMap {
       case Validated.Valid(xs) =>
         Task.point(SortedMap(xs: _*))
       case Validated.Invalid(errors) =>


### PR DESCRIPTION
The following improvements reduce the runtime from 22m to 4m on the main scala repo at Stripe with a cold coursier cache.

# First commit
While investigating performance of the `generate` command I noticed that threads were being under utilized. Here is an image of thread usage during a typical run:

![image](https://user-images.githubusercontent.com/39505601/46116206-17120400-c1b8-11e8-8ddc-d60de71237de.png)

As you can see, `pool-1-thread-*` threads appear to be executing sequentially. A thread dump revealed that these threads were fetching artifacts and calculating SHAs. I tracked this behavior down to a `traverse` on a list of Tasks, which serializes all of the tasks (Thanks to @ianoc for the tip here). Now [Task.gather](https://github.com/coursier/coursier/blob/master/cache/shared/src/main/scala/coursier/util/TaskGather.scala#L10), a parallel traverse from coursier, is used to parallelize these operations. You can see the difference in the thread visualization below:

![image](https://user-images.githubusercontent.com/39505601/46116276-81c33f80-c1b8-11e8-9ea6-024d64dec2cf.png)

# Second commit
Running `generate` with logging revealed two other things:

1. All SHA-1s were being calculated locally (attempts to download the SHA-1 were failing).
2. No artifacts have a SHA-256 checksum in the remote repo (at least no artifacts in the main Stripe Scala repo).

I noticed that SHA-1 downloads were failing because the `Artifact.extra` field never contained an artifact for a checksum. It appears this field contains artifacts for signatures, but not checksums. However, the `Artifact.checksumUrls` does indeed contain a URL for checksums, so now this field is queried instead.

Not a single artifact in the main scala monorepo at stripe has a SHA-256 checksum, so all SHA-256 checksums are now calculated locally so we save on network latency.