### PR TITLE
Another attempt to fix bad cases here

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -916,7 +916,7 @@ object Dependencies {
         }
       }
       group(g0).map { case (p, as) =>
-        p -> (group(as).map { case (a, prsub) => a -> group(prsub) })
+        p -> (group(as).map { case (a, prsub) => a -> group(prsub) }.sortBy { case (_, prs) => -prs.size })
       }
     }
 


### PR DESCRIPTION
We really need a principled way to format these files, but in the meantime we need a way that doesn't take a ridiculous amount of time. This PR reduces the `format-deps` step for one of our internal repositories from ~10+ minutes to a few seconds with no semantic change.

r? @oscar-stripe 