### PR TITLE
Change git_repository URLs to use 'https' schema

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl",
 
 git_repository(
     name = "io_bazel_rules_scala",
-    remote = "git://github.com/bazelbuild/rules_scala",
+    remote = "https://github.com/bazelbuild/rules_scala",
     commit = "5874a2441596fe9a0bf80e167a4d7edd945c221e" # update this as needed
 )
 

--- a/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
@@ -208,7 +208,7 @@ workspace(name = "$bazelName")
 
 git_repository(
   name = "io_bazel_rules_scala",
-  remote = "git://github.com/bazelbuild/rules_scala",
+  remote = "https://github.com/bazelbuild/rules_scala",
   commit = "73743b830ae98d13a946b25ad60cad5fee58e6d3",
 )
 


### PR DESCRIPTION
Some corporate firewalls might block the 'old school' git protocol. Using HTTPS for best compatibility.