### PR TITLE
Fix PACKAGE_NAME error

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/src/scala/com/github/johnynek/bazel_deps/BUILD
@@ -157,7 +157,7 @@ scala_binary(name = "parseproject",
                  "//3rdparty/jvm/org/slf4j:slf4j_simple",
              ],
              resources = ["templates/jar_artifact_backend.bzl"],
-             resource_strip_prefix = PACKAGE_NAME,
+             resource_strip_prefix = package_name(),
              main_class = "com.github.johnynek.bazel_deps.ParseProject",
              visibility = ["//visibility:public"])
 


### PR DESCRIPTION
Fixes

```
$ bazel run //:parse -- generate -r `pwd` -s 3rdparty/workspace.bzl -d dependencies.yaml
ERROR: /Users/tekumara/code3/bazel-deps/src/scala/com/github/johnynek/bazel_deps/BUILD:160:38: Traceback (most recent call last):
	File "/Users/tekumara/code3/bazel-deps/src/scala/com/github/johnynek/bazel_deps/BUILD", line 152
		scala_binary(name = "parseproject", srcs = ["Pa..."], <5 more arguments>)
	File "/Users/tekumara/code3/bazel-deps/src/scala/com/github/johnynek/bazel_deps/BUILD", line 160, in scala_binary
		PACKAGE_NAME
The value 'PACKAGE_NAME' has been removed in favor of 'package_name()', please use the latter (https://docs.bazel.build/versions/master/skylark/lib/native.html#package_name). You can temporarily allow the old name by using --incompatible_package_name_is_a_function=false
```