### PR TITLE
Ignore POM defined repositories during Aether resolution

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/AetherResolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/AetherResolver.scala
@@ -61,6 +61,7 @@ class AetherResolver(servers: List[MavenServer], resolverCachePath: Path) extend
     val s = MavenRepositorySystemUtils.newSession()
     val localRepo = new LocalRepository(resolverCachePath.toString)
     s.setLocalRepositoryManager(system.newLocalRepositoryManager(s, localRepo))
+    s.setIgnoreArtifactDescriptorRepositories(true)
     s
   }
 


### PR DESCRIPTION
Configure Aether to not use repositories definied in pom.xml for dependency
resolution of transitives. This prevents Aether from reaching out to external
repos which might be blocked by corporate firewall.

Signed-off-by: Gunnar Wagenknecht <gwagenknecht@salesforce.com>