### PR TITLE
add neverlink option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ A target may optionally add `exports` and `exclude` lists to a dependency. `expo
 artifact (such as: `com.twitter:scalding-core` in the above), and they should be listed in the dependencies. `exclude`
 list should also be only the group and artifact.
 
+It's possible to add `generateNeverlink` option to a dependency, which will make the generator to generate this dependency twice:
+1. With the normalized name as usual.
+2. With the name `${normalized}_neverlink` and neverlink is set as true.
+This option should be used only for java dependencies, it will be ignored in any other lang.
+
 Each group id can only appear once, so you should collocate dependencies by group. WARNING the parsing library
 we are using does not fail on duplicate keys, it just takes the last one, so watch out. It would be good
 to fix that, but writing a new yaml parser is out of scope.

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -427,7 +427,7 @@ case class MavenCoordinate(group: MavenGroup, artifact: MavenArtifactId, version
   def toDependencies(l: Language): Dependencies =
     Dependencies(Map(group ->
       Map(ArtifactOrProject(artifact.asString) ->
-        ProjectRecord(l, Some(version), None, None, None, None, None))))
+        ProjectRecord(l, Some(version), None, None, None, None, None, None))))
 }
 
 object MavenCoordinate {
@@ -593,7 +593,8 @@ case class ProjectRecord(
   exports: Option[Set[(MavenGroup, ArtifactOrProject)]],
   exclude: Option[Set[(MavenGroup, ArtifactOrProject)]],
   generatesApi: Option[Boolean],
-  processorClasses: Option[Set[ProcessorClass]]) {
+  processorClasses: Option[Set[ProcessorClass]],
+  generateNeverlink: Option[Boolean]) {
 
 
   // Cache this

--- a/src/scala/com/github/johnynek/bazel_deps/Target.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Target.scala
@@ -137,9 +137,8 @@ case class Target(
       if (!licenses.isEmpty) renderList(Doc.text("["), licenses.toList, Doc.text("]"))(quote)
       else Doc.empty
 
-    def generateTarget(neverlink: Boolean = false): Doc = {
-      var targetName = name.name
-      var targetArgs = List(
+    def generateTarget(neverlink: Boolean): Doc = {
+      val defaultArgs = List(
         visibilityDoc,
         "deps" -> labelList(deps),
         "licenses" -> renderLicenses(licenses),
@@ -149,19 +148,17 @@ case class Target(
         "runtime_deps" -> labelList(runtimeDeps),
         "exported_plugins" -> renderExportedPlugins(processorClasses)
       )
-
-      if (neverlink) {
-        targetName += "_neverlink"
-        targetArgs = targetArgs :+ (("neverlink", Doc.text("1")))
-      }
+      val (targetName, targetArgs) =
+        if (neverlink) (name.name + "_neverlink", defaultArgs :+ (("neverlink", Doc.text("1"))))
+        else (name.name, defaultArgs)
 
       sortKeys(targetType, targetName, targetArgs) + renderPlugins(processorClasses, exports, generatesApi, licenses) + Doc.line
     }
 
     if (!generateNeverlink) {
-      generateTarget()
+      generateTarget(neverlink = false)
     } else {
-      generateTarget() + generateTarget(true)
+      generateTarget(neverlink = false) + generateTarget(neverlink = true)
     }
   }
 }

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -326,7 +326,8 @@ object Writer {
                       runtimeDeps = runtime_deps -- uvexports,
                       processorClasses = getProcessorClasses(u),
                       generatesApi = getGeneratesApi(u),
-                      licenses = licenses)
+                      licenses = licenses,
+                      generateNeverlink = getGenerateNeverlink(u))
                   case Language.Kotlin =>
                     Target(lang,
                       kind = Target.Import,
@@ -382,6 +383,12 @@ object Writer {
           m <- model.dependencies.toMap.get(u.group)
           projectRecord <- m.get(ArtifactOrProject(u.artifact.asString))
         } yield projectRecord.generatesApi.getOrElse(false)).getOrElse(false)
+
+      def getGenerateNeverlink(u: UnversionedCoordinate): Boolean =
+        (for {
+          m <- model.dependencies.toMap.get(u.group)
+          projectRecord <- m.get(ArtifactOrProject(u.artifact.asString))
+        } yield projectRecord.generateNeverlink.getOrElse(false)).getOrElse(false)
 
       Traverse[List].traverse[E, UnversionedCoordinate, Target](allUnversioned.toList)(targetFor(_))
     }

--- a/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/maven/Tool.scala
@@ -170,6 +170,7 @@ object Tool {
             None,
             None,
             None,
+            None,
             None))
       }
       .toList

--- a/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelGenerators.scala
@@ -24,7 +24,7 @@ object ModelGenerators {
     exports <- Gen.option(Gen.listOfN(exp, join(mavenGroupGen, artifactOrProjGen)).map(_.toSet))
     exclude <- Gen.option(Gen.listOfN(exc, join(mavenGroupGen, artifactOrProjGen)).map(_.toSet))
     processorClasses <- Gen.option(Gen.listOfN(pcs, processorClassGen).map(_.toSet))
-  } yield ProjectRecord(lang, v, m, exports, exclude, None, processorClasses)
+  } yield ProjectRecord(lang, v, m, exports, exclude, None, processorClasses, None)
 
   def depGen(o: Options): Gen[Dependencies] = {
     val (l1, ls) = o.getLanguages match {

--- a/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
@@ -33,7 +33,7 @@ class ModelTest extends FunSuite {
     val lang = Language.Scala.default
     val deps = Dependencies(Map(
       MavenGroup("com.twitter") -> Map(
-        ArtifactOrProject("finagle") -> ProjectRecord(lang, Some(Version("0.1")), Some(Set(Subproject(""), Subproject("core"))), None, None, None, None)
+        ArtifactOrProject("finagle") -> ProjectRecord(lang, Some(Version("0.1")), Some(Set(Subproject(""), Subproject("core"))), None, None, None, None, None)
       )
     ))
 

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
@@ -319,6 +319,60 @@ class ParseTest extends FunSuite {
         None)))
   }
 
+  test("parse a file that has generateNeverlink set to true") {
+    val str = """dependencies:
+                |  org.apache.tomcat:
+                |    tomcat-catalina:
+                |      version: "7.0.57"
+                |      lang: java
+                |      generateNeverlink: true
+                |""".stripMargin('|')
+
+    assert(Decoders.decodeModel(Yaml, str) ==
+      Right(Model(
+        Dependencies(
+          MavenGroup("org.apache.tomcat") ->
+            Map(ArtifactOrProject("tomcat-catalina") ->
+              ProjectRecord(
+                Language.Java,
+                Some(Version("7.0.57")),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(true)))),
+        None,
+        None)))
+  }
+
+  test("parse a file that has generateNeverlink set to false") {
+    val str = """dependencies:
+                |  org.apache.tomcat:
+                |    tomcat-catalina:
+                |      version: "7.0.57"
+                |      lang: java
+                |      generateNeverlink: false
+                |""".stripMargin('|')
+
+    assert(Decoders.decodeModel(Yaml, str) ==
+      Right(Model(
+        Dependencies(
+          MavenGroup("org.apache.tomcat") ->
+            Map(ArtifactOrProject("tomcat-catalina") ->
+              ProjectRecord(
+                Language.Java,
+                Some(Version("7.0.57")),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(false)))),
+        None,
+        None)))
+  }
+
   /*
    * TODO make this test pass
    * see: https://github.com/johnynek/bazel-deps/issues/15

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTest.scala
@@ -30,6 +30,7 @@ class ParseTest extends FunSuite {
                 None,
                 None,
                 None,
+                None,
                 None))),
           None,
           None)))
@@ -59,6 +60,7 @@ class ParseTest extends FunSuite {
                 Language.Scala(Version("2.11.7"), true),
                 Some(Version("0.16.0")),
                 Some(Set("core", "args", "date").map(Subproject(_))),
+                None,
                 None,
                 None,
                 None,
@@ -101,6 +103,7 @@ class ParseTest extends FunSuite {
                 Language.Scala(Version("2.11.7"), true),
                 Some(Version("0.16.0")),
                 Some(Set("", "core", "args", "date").map(Subproject(_))),
+                None,
                 None,
                 None,
                 None,
@@ -147,7 +150,8 @@ class ParseTest extends FunSuite {
                 None,
                 None,
                 None,
-                Some(Set(ProcessorClass("com.google.auto.value.processor.AutoValueProcessor")))))),
+                Some(Set(ProcessorClass("com.google.auto.value.processor.AutoValueProcessor"))),
+                None))),
         None,
         None)))
   }
@@ -174,7 +178,8 @@ class ParseTest extends FunSuite {
                 None,
                 None,
                 Some(false),
-                Some(Set(ProcessorClass("com.google.auto.value.processor.AutoValueProcessor")))))),
+                Some(Set(ProcessorClass("com.google.auto.value.processor.AutoValueProcessor"))),
+                None))),
         None,
         None)))
   }
@@ -201,7 +206,8 @@ class ParseTest extends FunSuite {
                 None,
                 None,
                 Some(true),
-                Some(Set(ProcessorClass("com.google.auto.value.processor.AutoValueProcessor")))))),
+                Some(Set(ProcessorClass("com.google.auto.value.processor.AutoValueProcessor"))),
+                None))),
         None,
         None)))
   }
@@ -222,6 +228,7 @@ class ParseTest extends FunSuite {
               ProjectRecord(
                 Language.Java,
                 Some(Version("1.5")),
+                None,
                 None,
                 None,
                 None,
@@ -252,6 +259,7 @@ class ParseTest extends FunSuite {
                 None,
                 None,
                 None,
+                None,
                 None))),
         None,
         None)))
@@ -273,6 +281,7 @@ class ParseTest extends FunSuite {
               ProjectRecord(
                 Language.Java,
                 Some(Version("1.5")),
+                None,
                 None,
                 None,
                 None,
@@ -303,6 +312,7 @@ class ParseTest extends FunSuite {
                 None,
                 None,
                 Some(Set((MavenGroup("foo"), ArtifactOrProject(MavenArtifactId("bar:so:fancy"))))),
+                None,
                 None,
                 None))),
         None,

--- a/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ParseTestCasesTest.scala
@@ -12,7 +12,7 @@ class ParseTestCasesTest extends FunSuite {
       Map(
         MavenGroup("n2rr") ->
           Map(
-            ArtifactOrProject("zmup") -> ProjectRecord(Java,Some(Version("019")),Some(Set(Subproject("wcv"))),Some(Set((MavenGroup("j9szw4"),ArtifactOrProject("i")))),None,None,None)
+            ArtifactOrProject("zmup") -> ProjectRecord(Java,Some(Version("019")),Some(Set(Subproject("wcv"))),Some(Set((MavenGroup("j9szw4"),ArtifactOrProject("i")))),None,None,None,None)
           )
         )),Some(Replacements(Map())),None)
 


### PR DESCRIPTION
related to #68.
Adding an option to generate a dependency with `neverlink` option.
The reason why I duplicate each target with `neverlink` option is to allow using neverlink option on a specific build targets while other build targets could use the regular dependency target.