### PR TITLE
Update README to fix broken instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ For example, if your project is located at `MY_PROJ_DIR`, your dependencies file
 dependencies you need to do the following:
 
 ```bash
-# Build the ParseProject binary
+# Build the ParseProject deploy JAR
 cd $BAZEL_DEPS
-bazel build //:parse
+bazel build src/scala/com/github/johnynek/bazel_deps/parseproject_deploy.jar
 # Run parseproject on the dependencies.yaml in MY_PROJ_DIR, generating the 3rdparty/ dir.
 cd $MY_PROJ_DIR
 $BAZEL_DEPS/gen_maven_deps.sh generate --repo-root "$MY_PROJ_DIR" --sha-file 3rdparty/workspace.bzl --deps dependencies.yaml

--- a/README.md
+++ b/README.md
@@ -32,12 +32,8 @@ For example, if your project is located at `MY_PROJ_DIR`, your dependencies file
 dependencies you need to do the following:
 
 ```bash
-# Build the ParseProject deploy JAR
 cd $BAZEL_DEPS
-bazel build src/scala/com/github/johnynek/bazel_deps/parseproject_deploy.jar
-# Run parseproject on the dependencies.yaml in MY_PROJ_DIR, generating the 3rdparty/ dir.
-cd $MY_PROJ_DIR
-$BAZEL_DEPS/gen_maven_deps.sh generate --repo-root "$MY_PROJ_DIR" --sha-file 3rdparty/workspace.bzl --deps dependencies.yaml
+bazel run ://parse generate --repo-root "$MY_PROJ_DIR" --sha-file 3rdparty/workspace.bzl --deps dependencies.yaml
 ```
 
 The final result in `MY_PROJ_DIR` will look like this

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dependencies you need to do the following:
 
 ```bash
 cd $BAZEL_DEPS
-bazel run ://parse generate --repo-root "$MY_PROJ_DIR" --sha-file 3rdparty/workspace.bzl --deps dependencies.yaml
+bazel run //:parse generate -- --repo-root "$MY_PROJ_DIR" --sha-file 3rdparty/workspace.bzl --deps dependencies.yaml
 ```
 
 The final result in `MY_PROJ_DIR` will look like this


### PR DESCRIPTION
Instructions in `README.md` currently won't work because `//:parse` doesn't build the deploy JAR that `gen_maven_deps.sh` looks for.