### PR TITLE
Label -> fromRoot: add // before empty root

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/Label.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Label.scala
@@ -11,7 +11,7 @@ case class Label(workspace: Option[String], path: Path, name: String) {
     val ws = workspace.fold("") { nm => s"@$nm" }
     path.parts match {
       case Nil =>
-        if (nmPart.isEmpty) ws
+        if (nmPart.isEmpty) s"$ws//"
         else s"$ws//$nmPart"
       case ps => ps.mkString(s"$ws//", "/", nmPart)
     }


### PR DESCRIPTION
In a case of an empty third party directory, we'll
get visilibity  of ":__subpackages__" which will
deny access from higher packages in the same third
party directory. This is an attempt to fix that.