### PR TITLE
Update rules_scala to pull in https for central.maven.org

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl",
 git_repository(
     name = "io_bazel_rules_scala",
     remote = "https://github.com/bazelbuild/rules_scala",
-    commit = “a676633dc14d8239569affb2acafbef255df3480” # HEAD as of 2020-01-15, update this as needed
+    commit = "a676633dc14d8239569affb2acafbef255df3480" # HEAD as of 2020-01-15, update this as needed
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl",
 git_repository(
     name = "io_bazel_rules_scala",
     remote = "https://github.com/bazelbuild/rules_scala",
-    commit = "0f89c210ade8f4320017daf718a61de3c1ac4773" # HEAD as of 2019-10-25, update this as needed
+    commit = “a676633dc14d8239569affb2acafbef255df3480” # HEAD as of 2020-01-15, update this as needed
 )
 
 http_archive(


### PR DESCRIPTION
Trying to pull in https://github.com/bazelbuild/rules_scala/pull/920

Changes since the last update:
https://github.com/bazelbuild/rules_scala/compare/0f89c21...a676633