### PR TITLE
Make https://repo.maven.apache.org/maven2/ the default resolver URL

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -1261,7 +1261,7 @@ case class Options(
   }
   def getResolvers: List[MavenServer] =
     resolvers.getOrElse(
-      List(MavenServer("central", "default", "http://central.maven.org/maven2/")))
+      List(MavenServer("mavencentral", "default", "https://repo.maven.apache.org/maven2/")))
 
   def getTransitivity: Transitivity =
     transitivity.getOrElse(Transitivity.Exports)


### PR DESCRIPTION
[Given that maven now requires all requests to be made over `HTTPS`](https://support.sonatype.com/hc/en-us/articles/360041287334), update the default resolver accordingly to use https://repo.maven.apache.org/maven2/.