### PR TITLE
Stop the workflow from running on non master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-
 jobs:
   native-image:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The workflow shouldn't happen on pull requests or non master branches