### PR TITLE
Fix 'else' branch of conditional in update_dependencies.sh

### DIFF
--- a/ci_scripts/make_update_dependencies.sh
+++ b/ci_scripts/make_update_dependencies.sh
@@ -19,7 +19,7 @@ elif [ "\$(uname -s)" == "Darwin" ]; then
   BAZEL_DEPS_URL=https://github.com/${GITHUB_REPOSITORY}/releases/download/${BAZEL_DEPS_VERSION}/bazel-deps-macos
   BAZEL_DEPS_SHA256=${MACOS_SHA}
 else
-  "Your platform \$(uname -s) is unsupported, sorry"
+  echo "Your platform '\$(uname -s)' is unsupported, sorry"
   exit 1
 fi
 


### PR DESCRIPTION
### Description 

Currently if the `else` branch is run bash will attempt to run the string as a command. 