### PR TITLE
Make targets for replacements have public visibility

### DIFF
--- a/3rdparty/jvm/org/scala_lang/BUILD
+++ b/3rdparty/jvm/org/scala_lang/BUILD
@@ -6,7 +6,7 @@ scala_library(
         "@io_bazel_rules_scala_scala_compiler//:io_bazel_rules_scala_scala_compiler"
     ],
     visibility = [
-        "//3rdparty/jvm:__subpackages__"
+        "//visibility:public"
     ]
 )
 
@@ -18,7 +18,7 @@ scala_library(
         "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"
     ],
     visibility = [
-        "//3rdparty/jvm:__subpackages__"
+        "//visibility:public"
     ]
 )
 
@@ -30,7 +30,7 @@ scala_library(
         "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect"
     ],
     visibility = [
-        "//3rdparty/jvm:__subpackages__"
+        "//visibility:public"
     ]
 )
 

--- a/3rdparty/jvm/org/scala_lang/modules/BUILD
+++ b/3rdparty/jvm/org/scala_lang/modules/BUILD
@@ -6,7 +6,7 @@ scala_library(
         "@io_bazel_rules_scala_scala_parser_combinators//:io_bazel_rules_scala_scala_parser_combinators"
     ],
     visibility = [
-        "//3rdparty/jvm:__subpackages__"
+        "//visibility:public"
     ]
 )
 

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -376,7 +376,7 @@ object Writer {
               Target(lang,
                 kind = Target.Library,
                 name = Label.localTarget(pathInRoot, u, lang),
-                visibility = visibility(u),
+                visibility = Target.Visibility.Public,
                 exports = Set(lab),
                 jars = Set.empty,
                 licenses = licenses)
@@ -384,7 +384,7 @@ object Writer {
               Target(lang,
                 kind = Target.Import,
                 name = Label.localTarget(pathInRoot, u, lang),
-                visibility = visibility(u),
+                visibility = Target.Visibility.Public,
                 exports = Set(lab),
                 jars = Set.empty,
                 licenses = licenses)
@@ -392,7 +392,7 @@ object Writer {
               Target(lang,
                 kind = Target.Library,
                 name = Label.localTarget(pathInRoot, u, lang),
-                visibility = visibility(u),
+                visibility = Target.Visibility.Public,
                 exports = Set(lab),
                 jars = Set.empty,
                 licenses = licenses)


### PR DESCRIPTION
Fixes https://github.com/johnynek/bazel-deps/issues/173

For targets specified under `replacements`, this makes the corresponding `3rdparty/jvm` targets have public visibility.

This addresses behavior that I've found to be counterintuitive with `strictVisibility` enabled. I'd expect all dependencies declared in a `dependencies.yaml` to be visible to the workspace, regardless of whether it's under `dependencies` or `replacements`.
