### PR TITLE
Add command to generate a pom.xml to support Dependabot

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/src/scala/com/github/johnynek/bazel_deps/BUILD
@@ -4,6 +4,7 @@ scala_library(name = "depsmodel",
                   "//3rdparty/jvm/org/typelevel:cats_core",
                   "//3rdparty/jvm/org/typelevel:cats_kernel",
                   "//3rdparty/jvm/org/typelevel:paiges_core",
+                  "//3rdparty/jvm/org/scala_lang/modules:scala_xml",
               ],
               exports = [
                   "//3rdparty/jvm/org/typelevel:cats_core",
@@ -155,6 +156,7 @@ scala_binary(name = "parseproject",
              srcs = ["ParseProject.scala"],
              deps = [
                  ":makedeps",
+                 ":generatepom",
                  ":commands",
                  "//3rdparty/jvm/org/slf4j:slf4j_simple",
              ],
@@ -186,4 +188,15 @@ scala_library(name = "decoders",
                   "//3rdparty/jvm/io/circe:circe_generic",
               ],
               visibility = ["//visibility:public"])
+
+scala_library(name = "generatepom",
+             srcs = ["GeneratePom.scala"],
+             deps = [
+                 "//3rdparty/jvm/io/circe:circe_core",
+                 "//3rdparty/jvm/org/scala_lang/modules:scala_xml",
+                 ":circeyaml",
+                 ":depsmodel",
+                 ":decoders",
+             ],
+             visibility = ["//visibility:public"])
 

--- a/src/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/src/scala/com/github/johnynek/bazel_deps/BUILD
@@ -192,11 +192,16 @@ scala_library(name = "decoders",
 scala_library(name = "generatepom",
              srcs = ["GeneratePom.scala"],
              deps = [
+                 "//3rdparty/jvm/io/get_coursier:coursier_cache",
                  "//3rdparty/jvm/io/circe:circe_core",
                  "//3rdparty/jvm/org/scala_lang/modules:scala_xml",
                  ":circeyaml",
                  ":depsmodel",
                  ":decoders",
+                 ":graph",
+                 ":normalizer",
+                 ":coursier_resolver",
+                 ":resolver",
              ],
              visibility = ["//visibility:public"])
 

--- a/src/scala/com/github/johnynek/bazel_deps/Commands.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Commands.scala
@@ -116,6 +116,18 @@ object Command {
     (repoRoot |@| depsFile |@| shaFile |@| targetFile |@| buildifier |@| checkOnly |@| Verbosity.opt |@| disable3rdPartyInRepos).map(Generate(_, _, _, _, _, _, _, _))
   }
 
+  case class GeneratePom(deps: Path, pomFile: Path, groupId: String, artifactId: String, version: String, verbosity: Verbosity) extends Command
+  val generatePom = DCommand("generate-pom", "create pom xml file") {
+    val depsFile = Opts.option[Path]("deps", short = "d", help = "the ABSOLUTE path to your dependencies yaml file")
+    val pomFile = Opts.option[Path]("pom-file", short = "p", help = "the ABSOLUTE path to your pom xml file")
+    val groupId = Opts.option[String]("group-id", short = "g", help = "the id of the project's group")
+    val artifactId = Opts.option[String]("artifact-id", short = "a", help = "the id of the artifact (project)")
+    val version = Opts.option[String]("version", short = "v", help = "the version of the artifact under the specified group")
+
+
+    (depsFile |@| pomFile |@| groupId |@| artifactId |@| version |@| Verbosity.opt).map(GeneratePom(_, _, _, _, _, _))
+  }
+
   case class FormatDeps(deps: Path, overwrite: Boolean, verbosity: Verbosity) extends Command
   val format = DCommand("format-deps", "format the dependencies yaml file") {
     val depsFile = Opts.option[Path]("deps", short = "d", help = "the ABSOLUTE path to your dependencies yaml file")
@@ -158,7 +170,7 @@ object Command {
 
   val command: DCommand[Command] =
     DCommand(name = "bazel-deps", header = "a tool to manage transitive external Maven dependencies for bazel") {
-      (Opts.help :: (List(generate, format, mergeDeps, addDep).map(Opts.subcommand(_))))
+      (Opts.help :: (List(generate, format, mergeDeps, addDep, generatePom).map(Opts.subcommand(_))))
         .reduce(_.orElse(_))
     }
 }

--- a/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/DepsModel.scala
@@ -755,7 +755,7 @@ case class Dependencies(toMap: Map[MavenGroup, Map[ArtifactOrProject, ProjectRec
       .map { case (mavenGroup, map) =>
         map.map { case (artifactId, projectRecord) =>
           val modules = projectRecord.modules
-          modules.getOrElse(Set.empty).toList.sortBy(_.asString).map {
+          modules.getOrElse(Set(new Subproject(""))).toList.sortBy(_.asString).map {
             module =>
               val p = new scala.xml.PrettyPrinter(80, 2)
               <dependency>

--- a/src/scala/com/github/johnynek/bazel_deps/GeneratePom.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/GeneratePom.scala
@@ -83,14 +83,13 @@ object GeneratePom {
             }
         }
 
-
-
         val pomXml = <project>
           <modelVersion>4.0.0</modelVersion>
 
           <groupId>{groupId}</groupId>
           <artifactId>{artifactId}</artifactId>
           <version>{version}</version>
+
           <dependencies>
             {mavenCoordinateXml}
           </dependencies>

--- a/src/scala/com/github/johnynek/bazel_deps/GeneratePom.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/GeneratePom.scala
@@ -1,0 +1,48 @@
+package com.github.johnynek.bazel_deps
+
+import java.io.File
+
+import scala.util.{Failure, Success}
+
+object GeneratePom {
+  def readModel(path: File): Either[String, Model] = {
+    val content: Either[String, String] =
+      Model.readFile(path) match {
+        case Success(str) => Right(str)
+        case Failure(err) =>
+          Left(s"[ERROR]: Failed to read ${path}.\n$err")
+      }
+
+    content.right.flatMap { c =>
+      Decoders.decodeModel(Yaml, c) match {
+        case Right(m) => Right(m)
+        case Left(err) => Left(s"[ERROR]: Failed to parse ${path}.\n$err")
+      }
+    }
+  }
+
+  def apply(deps: File, pomFile: File, groupId: String, artifactId: String, version: String): Unit = {
+    readModel(deps) match {
+      case Left(msg) => System.err.println(msg)
+      case Right(model) =>
+        val p = new scala.xml.PrettyPrinter(80, 2)
+        val pomXml = <project>
+          <modelVersion>4.0.0</modelVersion>
+
+          <groupId>{groupId}</groupId>
+          <artifactId>{artifactId}</artifactId>
+          <version>{version}</version>
+
+          {model.toXml}
+
+        </project>
+
+        scala.xml.XML.save(
+          pomFile.toString,
+          scala.xml.XML.loadString(p.format(pomXml)),
+          "UTF-8",
+          true
+        )
+    }
+  }
+}

--- a/src/scala/com/github/johnynek/bazel_deps/GeneratePom.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/GeneratePom.scala
@@ -2,6 +2,8 @@ package com.github.johnynek.bazel_deps
 
 import java.io.File
 
+import cats.implicits._
+import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 object GeneratePom {
@@ -21,22 +23,80 @@ object GeneratePom {
     }
   }
 
+  private def resolve[F[_]](model: Model, resolver: Resolver[F]): F[(Graph[MavenCoordinate, Unit])] = {
+    import resolver.resolverMonad
+
+    val deps = model.dependencies
+    resolver.buildGraph(deps.roots.toList.sorted, model)
+      .flatMap { graph =>
+        // This is a defensive check that can be removed as we add more tests
+        resolverMonad.catchNonFatal {
+          deps.roots.foreach { m => require(graph.nodes(m), s"$m") }
+          graph
+        }
+      }
+      .flatMap { graph =>
+        Normalizer(graph, deps.roots, model.getOptions.getVersionConflictPolicy) match {
+          case None =>
+            val output = graph.nodes.groupBy(_.unversioned)
+              .mapValues { _.map(_.version).toList.sorted }
+              .filter { case (_, s) => s.lengthCompare(1) > 0 }
+              .map { case (u, vs) => s"""${u.asString}: ${vs.mkString(", ")}\n""" }
+              .mkString("\n")
+            resolverMonad.raiseError(new Exception(
+              s"could not normalize versions:\n$output"))
+          case Some(normalized) =>
+
+            /**
+             * Make sure all the optional versioned items were found
+             */
+            val uvNodes = normalized.nodes.map(_.unversioned)
+            val check = deps.unversionedRoots.filterNot { u =>
+              uvNodes(u) || model.getReplacements.get(u).isDefined
+            }.toList match {
+              case Nil => resolverMonad.pure(())
+              case missing =>
+                val output = missing.map(_.asString).mkString(" ")
+                resolverMonad.raiseError(new Exception(s"Missing unversioned deps in the normalized graph: $output"))
+            }
+
+            for {
+              _ <- check
+            } yield (normalized)
+        }
+      }
+  }
+
   def apply(deps: File, pomFile: File, groupId: String, artifactId: String, version: String): Unit = {
     readModel(deps) match {
       case Left(msg) => System.err.println(msg)
       case Right(model) =>
-        val p = new scala.xml.PrettyPrinter(80, 2)
+        val ec = scala.concurrent.ExecutionContext.Implicits.global
+        val resolver = new CoursierResolver(model.getOptions.getResolvers, ec, 3600.seconds)
+        val mavenCoordinateXml = resolver.run(resolve(model, resolver)) match {
+          case Failure(err) =>
+            Left(s"[ERROR]: Resolution failed ${err}.\n$err")
+          case Success((normalized)) =>
+            normalized.nodes.toList.map {
+              mv =>
+                mv.toXml
+            }
+        }
+
+
+
         val pomXml = <project>
           <modelVersion>4.0.0</modelVersion>
 
           <groupId>{groupId}</groupId>
           <artifactId>{artifactId}</artifactId>
           <version>{version}</version>
-
-          {model.toXml}
-
+          <dependencies>
+            {mavenCoordinateXml}
+          </dependencies>
         </project>
 
+        val p = new scala.xml.PrettyPrinter(80, 2)
         scala.xml.XML.save(
           pomFile.toString,
           scala.xml.XML.loadString(p.format(pomXml)),

--- a/src/scala/com/github/johnynek/bazel_deps/ParseProject.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/ParseProject.scala
@@ -21,6 +21,8 @@ object ParseProject {
             MergeDeps(ms, out)
           case Command.AddDep(yaml, lang, coords, _) =>
             MergeDeps.addDep(yaml, lang, coords)
+          case gen: Command.GeneratePom =>
+            GeneratePom(gen.deps.toFile, gen.pomFile.toFile, gen.groupId, gen.artifactId, gen.version)
         }
     }
   }

--- a/test/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/test/scala/com/github/johnynek/bazel_deps/BUILD
@@ -8,7 +8,10 @@ scala_library(name = "gencheats",
 scala_test(name = "modeltest",
            srcs = ["ModelTest.scala"],
            size = "small",
-           deps = ["//src/scala/com/github/johnynek/bazel_deps:depsmodel"])
+           deps = [
+               "//src/scala/com/github/johnynek/bazel_deps:depsmodel",
+               "//3rdparty/jvm/org/scala_lang/modules:scala_xml",
+               ])
 
 scala_test(name = "graphtest",
            srcs = ["GraphTest.scala"],

--- a/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
@@ -105,6 +105,28 @@ class ModelTest extends FunSuite {
     val lang = Language.Scala.default
     val deps = Dependencies(Map(
       MavenGroup("com.twitter") -> Map(
+        ArtifactOrProject("finagle") -> ProjectRecord(lang, Some(Version("0.1")), None, None, None, None, None, None)
+      )
+    ))
+    val model = new Model(deps, None, None)
+    val expected_xml =
+      <dependencies>
+        <dependency>
+          <groupId>com.twitter</groupId>
+          <artifactId>finagle</artifactId>
+          <version>0.1</version>
+        </dependency>
+      </dependencies>
+
+    val p = new scala.xml.PrettyPrinter(80, 2)
+    assert(p.format(model.toXml) == p.format(expected_xml))
+  }
+
+
+  test("Model toXml with subprojects"){
+    val lang = Language.Scala.default
+    val deps = Dependencies(Map(
+      MavenGroup("com.twitter") -> Map(
         ArtifactOrProject("finagle") -> ProjectRecord(lang, Some(Version("0.1")), Some(Set(Subproject(""), Subproject("core"))), None, None, None, None, None)
       )
     ))

--- a/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
@@ -1,7 +1,7 @@
 package com.github.johnynek.bazel_deps
 
-import org.scalatest.FunSuite
 import cats.data.Validated
+import org.scalatest.FunSuite
 
 class ModelTest extends FunSuite {
   test("specific versions sort correctly") {
@@ -99,5 +99,31 @@ class ModelTest extends FunSuite {
 
     // special: remove default packaging
     assert(MavenArtifactId("foo:jar").addSuffix("_1").asString == "foo_1")
+  }
+
+  test("Model toXml"){
+    val lang = Language.Scala.default
+    val deps = Dependencies(Map(
+      MavenGroup("com.twitter") -> Map(
+        ArtifactOrProject("finagle") -> ProjectRecord(lang, Some(Version("0.1")), Some(Set(Subproject(""), Subproject("core"))), None, None, None, None, None)
+      )
+    ))
+    val model = new Model(deps, None, None)
+    val expected_xml =
+      <dependencies>
+        <dependency>
+          <groupId>com.twitter</groupId>
+          <artifactId>finagle</artifactId>
+          <version>0.1</version>
+        </dependency>
+        <dependency>
+          <groupId>com.twitter</groupId>
+          <artifactId>finagle-core</artifactId>
+          <version>0.1</version>
+        </dependency>
+      </dependencies>
+
+    val p = new scala.xml.PrettyPrinter(80, 2)
+    assert(p.format(model.toXml) == p.format(expected_xml))
   }
 }

--- a/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/ModelTest.scala
@@ -101,51 +101,16 @@ class ModelTest extends FunSuite {
     assert(MavenArtifactId("foo:jar").addSuffix("_1").asString == "foo_1")
   }
 
-  test("Model toXml"){
-    val lang = Language.Scala.default
-    val deps = Dependencies(Map(
-      MavenGroup("com.twitter") -> Map(
-        ArtifactOrProject("finagle") -> ProjectRecord(lang, Some(Version("0.1")), None, None, None, None, None, None)
-      )
-    ))
-    val model = new Model(deps, None, None)
+  test("MavenCoordinate toXml"){
+
+    val mavenCoordinate = new MavenCoordinate(MavenGroup("com.twitter"), MavenArtifactId("finagle"), Version("0.1"))
     val expected_xml =
-      <dependencies>
-        <dependency>
-          <groupId>com.twitter</groupId>
-          <artifactId>finagle</artifactId>
-          <version>0.1</version>
-        </dependency>
-      </dependencies>
-
+      <dependency>
+        <groupId>com.twitter</groupId>
+        <artifactId>finagle</artifactId>
+        <version>0.1</version>
+      </dependency>
     val p = new scala.xml.PrettyPrinter(80, 2)
-    assert(p.format(model.toXml) == p.format(expected_xml))
-  }
-
-
-  test("Model toXml with subprojects"){
-    val lang = Language.Scala.default
-    val deps = Dependencies(Map(
-      MavenGroup("com.twitter") -> Map(
-        ArtifactOrProject("finagle") -> ProjectRecord(lang, Some(Version("0.1")), Some(Set(Subproject(""), Subproject("core"))), None, None, None, None, None)
-      )
-    ))
-    val model = new Model(deps, None, None)
-    val expected_xml =
-      <dependencies>
-        <dependency>
-          <groupId>com.twitter</groupId>
-          <artifactId>finagle</artifactId>
-          <version>0.1</version>
-        </dependency>
-        <dependency>
-          <groupId>com.twitter</groupId>
-          <artifactId>finagle-core</artifactId>
-          <version>0.1</version>
-        </dependency>
-      </dependencies>
-
-    val p = new scala.xml.PrettyPrinter(80, 2)
-    assert(p.format(model.toXml) == p.format(expected_xml))
+    assert(p.format(mavenCoordinate.toXml) == p.format(expected_xml))
   }
 }


### PR DESCRIPTION
Apologies for the previously closed [PR](https://github.com/johnynek/bazel-deps/pull/306/files). First open source PR here 😄 . I thought I was opening a PR in my forked repo and wasn't ready for reviews yet. But, thanks for the quick suggestion! 

The reason for this PR is to allow for Dependabot scanning on JVM repositories that use Bazel. Dependabot is used to scan repositories for vulnerable dependencies. However, the tool only checks dependencies listed in `pom.xml` files. I have leveraged the existing custom Decoders to parse the `dependencies.yaml` file and added new methods to the DepModel to return dependencies in xml format. 

Example:

```
bazel run //:parse -- generate-pom -d "$(pwd)"/dependencies.yaml -p "$(pwd)"/pom.xml --group-id com.mycompany.app --artifact-id my-app --version 1
```
