### PR TITLE
Update Generate command with optional param to create a pom xml file

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/src/scala/com/github/johnynek/bazel_deps/BUILD
@@ -141,6 +141,7 @@ scala_library(name = "makedeps",
                  ":commands",
                  ":decoders",
                  ":depsmodel",
+                 ":createpom",
                  ":graph",
                  ":io",
                  ":normalizer",
@@ -186,4 +187,13 @@ scala_library(name = "decoders",
                   "//3rdparty/jvm/io/circe:circe_generic",
               ],
               visibility = ["//visibility:public"])
+
+scala_library(name = "createpom",
+             srcs = ["CreatePom.scala"],
+             deps = [
+                 "//3rdparty/jvm/org/scala_lang/modules:scala_xml",
+                 ":depsmodel",
+                 ":graph",
+             ],
+             visibility = ["//visibility:public"])
 

--- a/src/scala/com/github/johnynek/bazel_deps/Commands.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Commands.scala
@@ -59,6 +59,7 @@ object Command {
     shaFile: String,
     targetFile: Option[String],
     buildifier: Option[String],
+    pomFile: Option[String],
     checkOnly: Boolean,
     verbosity: Verbosity,
     disable3rdPartyInRepo: Boolean
@@ -104,6 +105,12 @@ object Command {
       metavar = "buildifier",
       help = "absolute path to buildifier binary, which will be called to format each generated BUILD file").orNone
 
+    val pomFile = Opts.option[String](
+      "pom-file",
+      short = "p",
+      metavar = "pom-file",
+      help = "absolute path to the pom xml file").orNone
+
     val checkOnly = Opts.flag(
       "check-only",
       help = "if set, the generated files are checked against the existing files but are not written; exits 0 if the files match").orFalse
@@ -113,7 +120,7 @@ object Command {
       "disable-3rdparty-in-repo",
       help = "If set it controls if we should print out the 3rdparty source tree in the repo or not.").orFalse
 
-    (repoRoot |@| depsFile |@| shaFile |@| targetFile |@| buildifier |@| checkOnly |@| Verbosity.opt |@| disable3rdPartyInRepos).map(Generate(_, _, _, _, _, _, _, _))
+    (repoRoot |@| depsFile |@| shaFile |@| targetFile |@| buildifier |@| pomFile |@| checkOnly |@| Verbosity.opt |@| disable3rdPartyInRepos).map(Generate(_, _, _, _, _, _, _, _, _))
   }
 
   case class FormatDeps(deps: Path, overwrite: Boolean, verbosity: Verbosity) extends Command

--- a/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
@@ -1,0 +1,40 @@
+package com.github.johnynek.bazel_deps
+import scala.xml._
+
+object CreatePom {
+  implicit class MavenCoordinateExtension(private val self: MavenCoordinate) extends AnyVal {
+    def toXml: Elem = {
+      <dependency>
+        <groupId>{self.group.asString}</groupId>
+        <artifactId>{self.artifact.asString}</artifactId>
+        <version>{self.version.asString}</version>
+      </dependency>
+    }
+  }
+
+  def translate(dependencies: Graph[MavenCoordinate, Unit]): String = {
+    val mavenCoordinateXml = dependencies.nodes.toList.map {
+      d => d.toXml
+    }
+
+    val pomXml = <project>
+      <modelVersion>4.0.0</modelVersion>
+
+      <dependencies>
+        {mavenCoordinateXml}
+      </dependencies>
+    </project>
+
+    val p = new scala.xml.PrettyPrinter(80, 2)
+    p.format(pomXml)
+  }
+
+  def apply(dependencies: Graph[MavenCoordinate, Unit], path: String): Unit = {
+    scala.xml.XML.save(
+      path,
+      scala.xml.XML.loadString(translate(dependencies)),
+      "UTF-8",
+      true
+    )
+  }
+}

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -41,6 +41,8 @@ object MakeDeps {
         logger.error("resolution and sha collection failed", err)
         System.exit(1)
       case Success((normalized, shas, duplicates)) =>
+        // creates pom xml when path is provided
+        if (g.pomFile.nonEmpty) { CreatePom(normalized,  g.pomFile.get ) }
         // build the BUILDs in thirdParty
         val targets = Writer.targets(normalized, model) match {
           case Right(t) => t

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -42,7 +42,7 @@ object MakeDeps {
         System.exit(1)
       case Success((normalized, shas, duplicates)) =>
         // creates pom xml when path is provided
-        if (g.pomFile.nonEmpty) { CreatePom(normalized,  g.pomFile.get ) }
+        g.pomFile.foreach { fileName => CreatePom(normalized, fileName) }
         // build the BUILDs in thirdParty
         val targets = Writer.targets(normalized, model) match {
           case Right(t) => t

--- a/test/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/test/scala/com/github/johnynek/bazel_deps/BUILD
@@ -124,4 +124,17 @@ scala_test(name = "target_test",
                "//src/scala/com/github/johnynek/bazel_deps:depsmodel",
                ])
 
+scala_test(name = "createpomtest",
+           srcs = ["CreatePomTest.scala"],
+           deps = [
+               "//3rdparty/jvm/io/circe:circe_core",
+               "//src/scala/com/github/johnynek/bazel_deps:circeyaml",
+               "//src/scala/com/github/johnynek/bazel_deps:decoders",
+               "//src/scala/com/github/johnynek/bazel_deps:depsmodel",
+               "//src/scala/com/github/johnynek/bazel_deps:makedeps",
+               "//src/scala/com/github/johnynek/bazel_deps:graph",
+                "//src/scala/com/github/johnynek/bazel_deps:createpom",
+                "//3rdparty/jvm/org/scala_lang/modules:scala_xml",
+               ])
+
 test_suite(name = "all_tests")

--- a/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
@@ -1,0 +1,63 @@
+package com.github.johnynek.bazel_deps
+
+import org.scalatest.FunSuite
+
+class CreatePomTest extends FunSuite{
+
+  test("CreatePom translates dependencies yaml file into pom xml file") {
+    val dependenciesYaml = """
+options:
+  buildHeader: [ "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")" ]
+  languages: [ "java", "scala:2.11.8" ]
+  resolverType: "coursier"
+  resolvers:
+    - id: "mavencentral"
+      type: "default"
+      url: https://repo.maven.apache.org/maven2/
+  transitivity: runtime_deps
+  versionConflictPolicy: highest
+
+dependencies:
+  com.lowagie:
+    itext:
+      lang: java
+      version: "2.1.7"
+      exclude:
+        - "bouncycastle:bcprov-jdk14"
+        - "bouncycastle:bcmail-jdk14"
+        - "bouncycastle:bctsp-jdk14"
+  org.xhtmlrenderer:
+    flying-saucer-pdf:
+      lang: java
+      version: "9.0.3"
+"""
+
+    val expectedPomXml =
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <dependencies>
+          <dependency>
+            <groupId>com.lowagie</groupId>
+            <artifactId>itext</artifactId>
+            <version>2.1.7</version>
+          </dependency>
+          <dependency>
+            <groupId>org.xhtmlrenderer</groupId>
+            <artifactId>flying-saucer-pdf</artifactId>
+            <version>9.0.3</version>
+          </dependency>
+          <dependency>
+            <groupId>org.xhtmlrenderer</groupId>
+            <artifactId>flying-saucer-core</artifactId>
+            <version>9.0.3</version>
+          </dependency>
+        </dependencies>
+      </project>
+
+      val model = Decoders.decodeModel(Yaml, dependenciesYaml).right.get
+      val (dependencies, _, _) = MakeDeps.runResolve(model, null).get
+      val p = new scala.xml.PrettyPrinter(80, 2)
+
+      assert(CreatePom.translate(dependencies) == p.format(expectedPomXml))
+  }
+}


### PR DESCRIPTION
The reason for this PR is to allow for Dependabot scanning on JVM repositories that use Bazel. Dependabot is used to scan repositories for vulnerable dependencies. However, the tool only checks dependencies listed in pom.xml files. 

An [initial design](https://github.com/johnynek/bazel-deps/pull/307) was to add this functionality as its own command. Since the Generate command already parses the `dependencies.yaml` and resolves versions for transitive dependencies, the Generate command was extended. When a `pomFile` option is passed to Generate,  a`pom.xml` file will be created alongside bazel targets.

Example

```
bazel run //:parse -- generate -r `pwd` -s 3rdparty/workspace.bzl -d dependencies.yaml --pom-file "$pwd"/pom.xml
```
